### PR TITLE
Reduce redundant RTG blitter setup writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.nodma
 *.audio
 PREFSFILE*
+rtg/tests/build/
 sd-boot/zzsd-device.h
 attic
 

--- a/rtg/blitter_cache.h
+++ b/rtg/blitter_cache.h
@@ -1,0 +1,74 @@
+/*
+ * Small helpers for suppressing redundant ZZ9000 blitter register writes.
+ *
+ * The firmware keeps the latest register values, so a repeated write of the
+ * same value to the same board can be skipped on slow Zorro II setup paths.
+ */
+
+#ifndef ZZ9000_BLITTER_CACHE_H
+#define ZZ9000_BLITTER_CACHE_H
+
+#include <stdint.h>
+
+struct BlitterRegisterCache {
+	const volatile void *registers;
+	uint32_t valid;
+	uint16_t src_pitch;
+	uint16_t user1;
+	uint16_t user2;
+	uint32_t rgb2;
+};
+
+enum {
+	BLITTER_CACHE_SRC_PITCH = 1u << 0,
+	BLITTER_CACHE_USER1     = 1u << 1,
+	BLITTER_CACHE_USER2     = 1u << 2,
+	BLITTER_CACHE_RGB2      = 1u << 3,
+};
+
+static inline void blitter_cache_reset(struct BlitterRegisterCache *cache)
+{
+	cache->registers = 0;
+	cache->valid = 0;
+	cache->src_pitch = 0;
+	cache->user1 = 0;
+	cache->user2 = 0;
+	cache->rgb2 = 0;
+}
+
+static inline void blitter_cache_select(struct BlitterRegisterCache *cache,
+	const volatile void *registers)
+{
+	if (cache->registers != registers) {
+		cache->registers = registers;
+		cache->valid = 0;
+	}
+}
+
+static inline int blitter_cache_write16_needed(struct BlitterRegisterCache *cache,
+	const volatile void *registers, uint32_t bit, uint16_t *slot, uint16_t value)
+{
+	blitter_cache_select(cache, registers);
+	if (!(cache->valid & bit) || *slot != value) {
+		*slot = value;
+		cache->valid |= bit;
+		return 1;
+	}
+
+	return 0;
+}
+
+static inline int blitter_cache_write32_needed(struct BlitterRegisterCache *cache,
+	const volatile void *registers, uint32_t bit, uint32_t *slot, uint32_t value)
+{
+	blitter_cache_select(cache, registers);
+	if (!(cache->valid & bit) || *slot != value) {
+		*slot = value;
+		cache->valid |= bit;
+		return 1;
+	}
+
+	return 0;
+}
+
+#endif

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -33,6 +33,7 @@
 
 #include "mntgfx-gcc.h"
 #include "zz9000.h"
+#include "blitter_cache.h"
 
 #define STR(s) #s
 #define XSTR(s) STR(s)
@@ -127,6 +128,7 @@ char dummies[128];
 
 struct ExecBase *SysBase;
 static struct ConfigDev *reserved_cd = NULL;
+static struct BlitterRegisterCache blitter_register_cache;
 
 static inline volatile struct GFXData *zz_gfxdata(struct BoardInfo *b) {
 	return (volatile struct GFXData *)b->CardData[ZZ_CARD_DATA_GFXDATA];
@@ -414,12 +416,32 @@ static inline void writeBlitterRGB(MNTZZ9KRegs* registers, ULONG color) {
 }
 
 static inline void writeBlitterSrcPitch(MNTZZ9KRegs* registers, UWORD srcpitch) {
-// This can't be cached here because the firmware doesn't cache it either!
-//	static UWORD old = 0;
-//	if(srcpitch != old) {
+	if (blitter_cache_write16_needed(&blitter_register_cache, registers,
+			BLITTER_CACHE_SRC_PITCH, &blitter_register_cache.src_pitch,
+			srcpitch)) {
 		zzwrite16(&registers->blitter_src_pitch, srcpitch);
-//		old = srcpitch;
-//	}
+	}
+}
+
+static inline void writeBlitterRGB2(MNTZZ9KRegs* registers, ULONG color) {
+	if (blitter_cache_write32_needed(&blitter_register_cache, registers,
+			BLITTER_CACHE_RGB2, &blitter_register_cache.rgb2, color)) {
+		zzwrite32(&registers->blitter_rgb2_hi, color);
+	}
+}
+
+static inline void writeBlitterUser1(MNTZZ9KRegs* registers, UWORD value) {
+	if (blitter_cache_write16_needed(&blitter_register_cache, registers,
+			BLITTER_CACHE_USER1, &blitter_register_cache.user1, value)) {
+		zzwrite16(&registers->blitter_user1, value);
+	}
+}
+
+static inline void writeBlitterUser2(MNTZZ9KRegs* registers, UWORD value) {
+	if (blitter_cache_write16_needed(&blitter_register_cache, registers,
+			BLITTER_CACHE_USER2, &blitter_register_cache.user2, value)) {
+		zzwrite16(&registers->blitter_user2, value);
+	}
 }
 
 static inline void writeBlitterDstPitch(MNTZZ9KRegs* registers, UWORD dstpitch) {
@@ -764,6 +786,7 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 	//b->DeleteFeature = (void *)NULL;
 
 	apply_card_settings(b, tool_types);
+	blitter_cache_reset(&blitter_register_cache);
 
 	return 1;
 }
@@ -965,7 +988,7 @@ void SetColorArray(__REGA0(struct BoardInfo *b), __REGD0(UWORD start), __REGD1(U
 
 	if (start >= 256) {
 		if (!b->CardData[ZZ_CARD_DATA_SECONDARY_PALETTE]) {
-			zzwrite16(&registers->blitter_user1, CARD_FEATURE_SECONDARY_PALETTE);
+			writeBlitterUser1(registers, CARD_FEATURE_SECONDARY_PALETTE);
 			zzwrite16(&registers->set_feature_status, 1);
 			b->CardData[ZZ_CARD_DATA_SECONDARY_PALETTE] = 1;
 		}
@@ -1466,7 +1489,7 @@ void BlitTemplate(__REGA0(struct BoardInfo *b), __REGA1(struct RenderInfo *r), _
 		writeBlitterSrcOffset(registers, zz_template_addr);
 
 		writeBlitterRGB(registers, t->FgPen);
-		zzwrite32(&registers->blitter_rgb2_hi, t->BgPen);
+		writeBlitterRGB2(registers, t->BgPen);
 
 		writeBlitterSrcPitch(registers, t->BytesPerRow);
 		writeBlitterDstPitch(registers, r->BytesPerRow);
@@ -1534,9 +1557,9 @@ void BlitPattern(__REGA0(struct BoardInfo *b), __REGA1(struct RenderInfo *r), __
 		writeBlitterSrcOffset(registers, zz_template_addr);
 
 		writeBlitterRGB(registers, pat->FgPen);
-		zzwrite32(&registers->blitter_rgb2_hi, pat->BgPen);
+		writeBlitterRGB2(registers, pat->BgPen);
 
-		zzwrite16(&registers->blitter_user1, mask);
+		writeBlitterUser1(registers, mask);
 		writeBlitterDstPitch(registers, r->BytesPerRow);
 		writeBlitterColorMode(registers, colormode | (pat->DrawMode << 8));
 		writeBlitterX1(registers, x);
@@ -1634,13 +1657,13 @@ void DrawLine(__REGA0(struct BoardInfo *b), __REGA1(struct RenderInfo *r), __REG
 
 		writeBlitterRGB(registers, l->FgPen);
 
-		zzwrite32(&registers->blitter_rgb2_hi, l->BgPen);
+		writeBlitterRGB2(registers, l->BgPen);
 
 		writeBlitterX1(registers, l->X);
 		writeBlitterY1(registers, l->Y);
 		writeBlitterX2(registers, l->dX);
 		writeBlitterY2(registers, l->dY);
-		zzwrite16(&registers->blitter_user1, l->Length);
+		writeBlitterUser1(registers, l->Length);
 		writeBlitterX3(registers, l->LinePtrn);
 		writeBlitterY3(registers, l->PatternShift | (l->pad << 8));
 
@@ -1801,7 +1824,7 @@ void BlitPlanar2Chunky(__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm),
 		writeBlitterX3(registers, w);
 		writeBlitterY3(registers, h);
 
-		zzwrite16(&registers->blitter_user2, zz_mask);
+		writeBlitterUser2(registers, zz_mask);
 
 		zzwrite16(&registers->blitter_op_p2c, mask | bm->Depth << 8);
 	}
@@ -1903,7 +1926,7 @@ void BlitPlanar2Direct(__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm),
 		writeBlitterX3(registers, w);
 		writeBlitterY3(registers, h);
 
-		zzwrite16(&registers->blitter_user2, zz_mask);
+		writeBlitterUser2(registers, zz_mask);
 
 		zzwrite16(&registers->blitter_op_p2d, mask | bm->Depth << 8);
 	}
@@ -2001,8 +2024,8 @@ void SetSpriteColor(__REGA0(struct BoardInfo *b), __REGD0(UBYTE idx), __REGD1(UB
 
 		zzwrite16(&registers->blitter_dma_op, OP_SPRITE_COLOR);
 	} else {
-		zzwrite16(&registers->blitter_user1, R);
-		zzwrite16(&registers->blitter_user2, B | (G << 8));
+		writeBlitterUser1(registers, R);
+		writeBlitterUser2(registers, B | (G << 8));
 		zzwrite16(&registers->sprite_colors, idx + 1);
 	}
 }

--- a/rtg/tests/Makefile
+++ b/rtg/tests/Makefile
@@ -1,0 +1,16 @@
+CC ?= cc
+CFLAGS ?= -O2 -g
+
+TARGET := build/register_cache_test
+
+.PHONY: test clean
+
+test: $(TARGET)
+	$(TARGET)
+
+$(TARGET): register_cache_test.c ../blitter_cache.h
+	@mkdir -p build
+	$(CC) -Wall -Wextra $(CFLAGS) -I.. -o $@ register_cache_test.c
+
+clean:
+	rm -rf build

--- a/rtg/tests/register_cache_test.c
+++ b/rtg/tests/register_cache_test.c
@@ -1,0 +1,79 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "blitter_cache.h"
+
+static int failures;
+
+static void expect_write(const char *name, int actual, int expected)
+{
+	if (actual != expected) {
+		printf("FAIL %-32s actual=%d expected=%d\n", name, actual, expected);
+		failures++;
+		return;
+	}
+
+	printf("ok   %s\n", name);
+}
+
+int main(void)
+{
+	struct BlitterRegisterCache cache;
+	uint16_t src_pitch_a = 0;
+	uint16_t src_pitch_b = 0;
+	uint16_t user1 = 0;
+	uint16_t user2 = 0;
+	uint32_t rgb2 = 0;
+	int regs_a;
+	int regs_b;
+
+	blitter_cache_reset(&cache);
+
+	expect_write("first src pitch writes",
+		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_SRC_PITCH,
+			&src_pitch_a, 256), 1);
+	expect_write("same src pitch skips",
+		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_SRC_PITCH,
+			&src_pitch_a, 256), 0);
+	expect_write("changed src pitch writes",
+		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_SRC_PITCH,
+			&src_pitch_a, 320), 1);
+	expect_write("different board writes",
+		blitter_cache_write16_needed(&cache, &regs_b, BLITTER_CACHE_SRC_PITCH,
+			&src_pitch_b, 320), 1);
+	expect_write("same value after board switch skips",
+		blitter_cache_write16_needed(&cache, &regs_b, BLITTER_CACHE_SRC_PITCH,
+			&src_pitch_b, 320), 0);
+
+	blitter_cache_reset(&cache);
+	expect_write("first user1 writes",
+		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_USER1,
+			&user1, 12), 1);
+	expect_write("same user1 skips",
+		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_USER1,
+			&user1, 12), 0);
+	expect_write("first user2 writes",
+		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_USER2,
+			&user2, 0x5a), 1);
+	expect_write("same user2 skips",
+		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_USER2,
+			&user2, 0x5a), 0);
+
+	expect_write("first rgb2 writes",
+		blitter_cache_write32_needed(&cache, &regs_a, BLITTER_CACHE_RGB2,
+			&rgb2, 0x11223344), 1);
+	expect_write("same rgb2 skips",
+		blitter_cache_write32_needed(&cache, &regs_a, BLITTER_CACHE_RGB2,
+			&rgb2, 0x11223344), 0);
+	expect_write("changed rgb2 writes",
+		blitter_cache_write32_needed(&cache, &regs_a, BLITTER_CACHE_RGB2,
+			&rgb2, 0x55667788), 1);
+
+	if (failures) {
+		printf("%d register cache test(s) failed\n", failures);
+		return 1;
+	}
+
+	printf("all register cache tests passed\n");
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add a small blitter register-cache helper and host test
- cache repeated Zorro II setup writes for source pitch, RGB2, user1, and user2 registers
- reset the cache after card settings are applied during init
- keep the change scoped to redundant setup-write suppression, without protocol or staging changes

## Validation
- make -C rtg/tests clean
- make -C rtg/tests test
- podman run --rm --security-opt label=disable -v /home/midwan/Github/zz9000-drivers:/src -w /src/rtg sacredbanana/amiga-compiler:m68k-amigaos sh -c 'export PATH=/opt/amiga/bin:$PATH && sh build.sh'\n\n## Review Notes\n- self-review found no blocking issues\n- built driver artifact: rtg/ZZ9000.card sha256 023ecd2e919dad406ec440f91ef02a3bf73b81d3b11d645ec91e41fc2b030f61\n- no template/pattern staging-cache or experimental hardware changes are included