### PR TITLE
Fix Zorro II RTG corruption regression

### DIFF
--- a/rtg/blitter_cache.h
+++ b/rtg/blitter_cache.h
@@ -58,6 +58,15 @@ static inline int blitter_cache_write16_needed(struct BlitterRegisterCache *cach
 	return 0;
 }
 
+static inline int blitter_cache_src_pitch_write_needed(struct BlitterRegisterCache *cache,
+	const volatile void *registers, uint16_t value)
+{
+	blitter_cache_select(cache, registers);
+	cache->src_pitch = value;
+	cache->valid &= ~BLITTER_CACHE_SRC_PITCH;
+	return 1;
+}
+
 static inline int blitter_cache_write32_needed(struct BlitterRegisterCache *cache,
 	const volatile void *registers, uint32_t bit, uint32_t *slot, uint32_t value)
 {

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -56,13 +56,13 @@ struct DOSBase;
 #define __saveds__
 
 #define DEVICE_VERSION 2
-#define DEVICE_REVISION 5
+#define DEVICE_REVISION 6
 #define REQUIRED_FW_VERSION_MAJOR 2
 #define REQUIRED_FW_VERSION_MINOR 0
 #define DEVICE_PRIORITY 0
 #define DEVICE_ID_STRING "$VER: ZZ9000.card+blitter " XSTR(DEVICE_VERSION) "." XSTR(DEVICE_REVISION) " " DEVICE_DATE
 #define DEVICE_NAME "ZZ9000.card"
-#define DEVICE_DATE "(17.05.2026)"
+#define DEVICE_DATE "(19.05.2026)"
 
 int __attribute__((no_reorder)) _start()
 {
@@ -433,9 +433,8 @@ static inline void writeBlitterRGB(MNTZZ9KRegs* registers, ULONG color) {
 }
 
 static inline void writeBlitterSrcPitch(MNTZZ9KRegs* registers, UWORD srcpitch) {
-	if (blitter_cache_write16_needed(&blitter_register_cache, registers,
-			BLITTER_CACHE_SRC_PITCH, &blitter_register_cache.src_pitch,
-			srcpitch)) {
+	if (blitter_cache_src_pitch_write_needed(&blitter_register_cache,
+			registers, srcpitch)) {
 		zzwrite16(&registers->blitter_src_pitch, srcpitch);
 	}
 }
@@ -723,7 +722,9 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 	b->PaletteChipType = PCT_MNT_ZZ9000;
 	b->GraphicsControllerType = GCT_MNT_ZZ9000;
 
-	b->Flags |= BIF_GRANTDIRECTACCESS | BIF_HARDWARESPRITE | BIF_FLICKERFIXER | BIF_VGASCREENSPLIT | BIF_PALETTESWITCH | BIF_BLITTER | BIF_CACHEMODECHANGE | BIF_VIDEOCAPTURE;
+	b->Flags |= BIF_GRANTDIRECTACCESS | BIF_HARDWARESPRITE | BIF_FLICKERFIXER | BIF_VGASCREENSPLIT | BIF_PALETTESWITCH | BIF_BLITTER | BIF_VIDEOCAPTURE;
+	if (b->CardFlags & CARDFLAG_ZORRO_3)
+		b->Flags |= BIF_CACHEMODECHANGE;
 
 	b->MoniSwitch = (UWORD)b->CardData[ZZ_CARD_DATA_MONITOR_SWITCH];
 	b->RGBFormats = ZZ_SUPPORTED_RGB_FORMATS;

--- a/rtg/tests/register_cache_test.c
+++ b/rtg/tests/register_cache_test.c
@@ -19,31 +19,29 @@ static void expect_write(const char *name, int actual, int expected)
 int main(void)
 {
 	struct BlitterRegisterCache cache;
-	uint16_t src_pitch_a = 0;
-	uint16_t src_pitch_b = 0;
 	uint16_t user1 = 0;
 	uint16_t user2 = 0;
 	uint32_t rgb2 = 0;
-	int regs_a;
-	int regs_b;
+	int regs_a = 0;
+	int regs_b = 0;
 
 	blitter_cache_reset(&cache);
 
 	expect_write("first src pitch writes",
-		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_SRC_PITCH,
-			&src_pitch_a, 256), 1);
-	expect_write("same src pitch skips",
-		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_SRC_PITCH,
-			&src_pitch_a, 256), 0);
+		blitter_cache_src_pitch_write_needed(&cache, &regs_a, 256), 1);
+	expect_write("same src pitch still writes",
+		blitter_cache_src_pitch_write_needed(&cache, &regs_a, 256), 1);
 	expect_write("changed src pitch writes",
-		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_SRC_PITCH,
-			&src_pitch_a, 320), 1);
+		blitter_cache_src_pitch_write_needed(&cache, &regs_a, 320), 1);
 	expect_write("different board writes",
-		blitter_cache_write16_needed(&cache, &regs_b, BLITTER_CACHE_SRC_PITCH,
-			&src_pitch_b, 320), 1);
-	expect_write("same value after board switch skips",
-		blitter_cache_write16_needed(&cache, &regs_b, BLITTER_CACHE_SRC_PITCH,
-			&src_pitch_b, 320), 0);
+		blitter_cache_src_pitch_write_needed(&cache, &regs_b, 320), 1);
+	expect_write("same value after board switch writes",
+		blitter_cache_src_pitch_write_needed(&cache, &regs_b, 320), 1);
+	if (cache.src_pitch != 320) {
+		printf("FAIL src pitch cache slot actual=%u expected=320\n",
+			(unsigned)cache.src_pitch);
+		failures++;
+	}
 
 	blitter_cache_reset(&cache);
 	expect_write("first user1 writes",


### PR DESCRIPTION
## Summary

- keep `BIF_CACHEMODECHANGE` enabled only for Zorro III boards
- restore unconditional writes for `blitter_src_pitch`
- update the register-cache test so source pitch writes are never skipped

## Root Cause

Issue #20 reported Workbench graphics corruption on Zorro II systems with the v2.1.0 driver while the same firmware worked with the v2.0.1 driver. The v2.1.0 driver had two Zorro-II-sensitive changes in common with the bad build: cache-mode advertising and source-pitch register write suppression.

The reporter tested two diagnostic binaries. Both worked, including the primary build that keeps direct Z2 solid-line drawing enabled, so the direct line path is not implicated. The fix keeps the shared primary changes only.

Fixes #20.

## Validation

- `make -C rtg/tests`
- Docker RTG build with `sacredbanana/amiga-compiler:m68k-amigaos`
- Reporter confirmed both diagnostic binaries fixed the Zorro II corruption
