### PR TITLE
audio: harden AHI and MHI playback state

### DIFF
--- a/ahi/driver/zz9000ax-ahi.c
+++ b/ahi/driver/zz9000ax-ahi.c
@@ -296,7 +296,6 @@ void WorkerProcess() {
   }
 
   uint32_t signals = 0;
-  uint32_t buf_offset = 0;
 
   Signal(ahi_data->t_mainproc, 1L << ahi_data->mainproc_signal);
 
@@ -339,21 +338,21 @@ void WorkerProcess() {
       write_reg(ahi_data->hw_addr, ZZ_REG_AUDIO_SCALE, AudioCtrl->ahiac_BuffSamples);
 
       // def. the faster way
-      CopyMem((void*)ahi_data->audio_buf_addr, (void*)ahi_data->audio_hw_buf_addr + buf_offset, bytes);
+      CopyMem((void*)ahi_data->audio_buf_addr, (void*)ahi_data->audio_hw_buf_addr + ahi_data->buf_offset, bytes);
       // byteswap, resample and play buffer
-      write_reg(ahi_data->hw_addr, ZZ_REG_AUDIO_SWAB, buf_offset>>8);
+      write_reg(ahi_data->hw_addr, ZZ_REG_AUDIO_SWAB, ahi_data->buf_offset>>8);
       overrun = read_reg(ahi_data->hw_addr, ZZ_REG_AUDIO_SWAB);
 #endif
 
       if (overrun == 1) {
         //memset((void*)ahi_data->audio_buf_addr, 0, ZZ_AX_AUDIO_BUFSZ);
-        buf_offset = 0;
+        ahi_data->buf_offset = 0;
       } else {
-        buf_offset += ZZ_AX_BYTES_PER_PERIOD;
+        ahi_data->buf_offset += ZZ_AX_BYTES_PER_PERIOD;
       }
 
-      if (buf_offset >= ZZ_AX_AUDIO_BUFSZ) {
-        buf_offset = 0;
+      if (ahi_data->buf_offset >= ZZ_AX_AUDIO_BUFSZ) {
+        ahi_data->buf_offset = 0;
       }
 
       (*AudioCtrl->ahiac_PostTimer)();
@@ -436,6 +435,24 @@ static void enable_hw_interrupt(struct z9ax* ahi_data) {
 #endif
 }
 
+static void disable_hw_interrupt(struct z9ax* ahi_data) {
+#ifdef REAL_HARDWARE
+  write_reg(ahi_data->hw_addr, ZZ_REG_AUDIO_CONFIG, 0);
+#else
+  (void)ahi_data;
+#endif
+}
+
+static void zero_hw_audio_ring(struct z9ax* ahi_data) {
+#ifdef REAL_HARDWARE
+  volatile uint8_t *hw_buf = (volatile uint8_t *)ahi_data->audio_hw_buf_addr;
+  uint32_t i;
+  for (i = 0; i < ZZ_AX_AUDIO_BUFSZ; i++) hw_buf[i] = 0;
+#else
+  (void)ahi_data;
+#endif
+}
+
 void destroy_interrupt(struct z9ax* ahi_data) {
   struct Interrupt* irq = &ahi_data->irq;
 
@@ -443,7 +460,7 @@ void destroy_interrupt(struct z9ax* ahi_data) {
 
 #ifdef REAL_HARDWARE
   // disable HW interrupt
-  write_reg(ahi_data->hw_addr, ZZ_REG_AUDIO_CONFIG, 0);
+  disable_hw_interrupt(ahi_data);
 
   Forbid();
   if (ahi_data->flags & ZZ_AX_DEVF_INT2MODE) {
@@ -567,6 +584,7 @@ static uint32_t __attribute__((used)) intAHIsub_AllocAudio(struct TagItem *tagLi
   ahi_data->mainproc_signal = -1;
   ahi_data->zorro_version = zorro;
   ahi_data->t_mainproc = FindTask(NULL);
+  ahi_data->buf_offset = 0;
   // FIXME: see also zz_template_addr in RTG driver
   uint32_t offset_tx = Z9AXBase->hw_size - 0x20000;
   ahi_data->audio_hw_buf_addr = hw_addr + 0x10000 + offset_tx;
@@ -648,11 +666,7 @@ static uint32_t __attribute__((used)) intAHIsub_AllocAudio(struct TagItem *tagLi
   // be played as a short burst before the worker writes the first mixed
   // period. ZZ_AX_AUDIO_BUFSZ is the full ring size (8 periods); zeroing all
   // of it means the DAC plays silence until real data lands.
-  {
-    volatile uint8_t *hw_buf = (volatile uint8_t *)ahi_data->audio_hw_buf_addr;
-    uint32_t i;
-    for (i = 0; i < ZZ_AX_AUDIO_BUFSZ; i++) hw_buf[i] = 0;
-  }
+  zero_hw_audio_ring(ahi_data);
 
   ahi_data->mainproc_signal = AllocSignal(-1);
   if (ahi_data->mainproc_signal == -1) {
@@ -687,9 +701,8 @@ static uint32_t __attribute__((used)) intAHIsub_AllocAudio(struct TagItem *tagLi
   // yields 960 samples (3840 bytes) for 48000Hz
   AudioCtrl->ahiac_BuffSamples = AudioCtrl->ahiac_MixFreq/50;
 
-  // Worker is up and the period size is initialized; safe to let the
-  // hardware start firing audio interrupts.
-  enable_hw_interrupt(ahi_data);
+  // Worker is up and the period size is initialized. Start() will reset
+  // the ring and enable hardware interrupts when AHI begins playback.
 
   // none of that weird timing
   return AHISF_KNOWSTEREO | AHISF_MIXING; // | AHISF_TIMING;
@@ -756,7 +769,15 @@ static void __attribute__((used)) intAHIsub_Stop(uint32_t Flags asm("d0"), struc
   struct z9ax *ahi_data = AudioCtrl->ahiac_DriverData;
   if (!ahi_data) return;
   if (Flags & AHISF_PLAY) {
+    Forbid();
     ahi_data->play_stop = 1;
+    disable_hw_interrupt(ahi_data);
+    ahi_data->buf_offset = 0;
+    Permit();
+
+    // Clear the 30 KB Zorro-side ring outside Forbid(); AHI serializes
+    // Start/Stop calls for this driver instance, and the hardware is off.
+    zero_hw_audio_ring(ahi_data);
   }
 }
 
@@ -764,7 +785,22 @@ static uint32_t __attribute__((used)) intAHIsub_Start(uint32_t flags asm("d0"), 
   struct z9ax *ahi_data = AudioCtrl->ahiac_DriverData;
   if (!ahi_data) return AHIE_OK;
   if (flags & AHISF_PLAY) {
+    Forbid();
+    disable_hw_interrupt(ahi_data);
+    ahi_data->buf_offset = 0;
+    ahi_data->play_stop = 1;
+    Permit();
+
+    // Clear the 30 KB Zorro-side ring outside Forbid(); play_stop remains
+    // set so the worker drops any stale signal instead of racing this
+    // silence pass.
+    zero_hw_audio_ring(ahi_data);
+
+    Forbid();
+    ahi_data->buf_offset = 0;
     ahi_data->play_stop = 0;
+    enable_hw_interrupt(ahi_data);
+    Permit();
   }
   // Returns AHIE_OK if successful.
   return AHIE_OK;
@@ -783,6 +819,8 @@ static int32_t __attribute__((used)) intAHIsub_GetAttr(uint32_t attr_ asm("d0"),
     case AHIDB_Frequencies:
       return ZZ_NUM_FREQS;
     case AHIDB_Frequency:
+      if (arg < 0 || arg >= ZZ_NUM_FREQS)
+        return def;
       return freqs[arg];
     case AHIDB_Index:
       for (int i = 0; i < ZZ_NUM_FREQS; i++) {

--- a/ahi/driver/zz9000ax-ahi.h
+++ b/ahi/driver/zz9000ax-ahi.h
@@ -7,6 +7,7 @@ struct z9ax {
   uint32_t hw_addr;
   uint32_t audio_buf_addr;
   uint32_t audio_hw_buf_addr;
+  uint32_t buf_offset;
   int8_t mainproc_signal;
   int8_t worker_signal;
   int8_t enable_signal;

--- a/mhi/mhizz9000.c
+++ b/mhi/mhizz9000.c
@@ -628,14 +628,14 @@ APTR i_MHIGetEmpty(REGA3(APTR mhi_handle), REGA6(struct MHI_LibBase *MHI_LibBase
 	if(!mp || !mp->BufferList) return NULL;
 
 	// Walk + RemHead must be protected against the soft-IRQ fillFifo()
-	// that reads from the same list head.
+	// that reads from the same list head. Return one completed buffer per
+	// call: callers use repeated GetEmpty calls to reclaim every buffer,
+	// and draining multiple nodes here would lose all but the last pointer.
 	Forbid();
-	for(;;) {
-		BufferNode = (struct ListNode *)mp->BufferList->mlh_Head;
-		if(BufferNode == NULL) break;
-		if(BufferNode->Header.mln_Succ == NULL) break;
-		if(BufferNode->Played == FALSE) break;
-
+	BufferNode = (struct ListNode *)mp->BufferList->mlh_Head;
+	if(BufferNode != NULL &&
+	   BufferNode->Header.mln_Succ != NULL &&
+	   BufferNode->Played != FALSE) {
 		mhi_buffer = BufferNode->Buffer;
 		RemHead((struct List *)mp->BufferList);
 		FreeVec(BufferNode);

--- a/tools/tests/test_repo_tooling.py
+++ b/tools/tests/test_repo_tooling.py
@@ -187,6 +187,48 @@ class RepoToolingTests(unittest.TestCase):
         self.assertLess(source.index("!mhi_buffer"),
                         source.index("AllocVec(sizeof(struct ListNode)"))
 
+    def test_mhi_get_empty_returns_one_buffer_per_call(self):
+        source = self.read("mhi/mhizz9000.c")
+        body = source[
+            source.index("APTR i_MHIGetEmpty"):
+            source.index("UBYTE i_MHIGetStatus")
+        ]
+        self.assertNotIn("for(;;)", body)
+        self.assertIn("BufferNode->Played != FALSE", body)
+        self.assertIn("mhi_buffer = BufferNode->Buffer;", body)
+        self.assertIn("RemHead((struct List *)mp->BufferList);", body)
+
+    def test_ahi_frequency_attr_rejects_bad_indices(self):
+        source = self.read("ahi/driver/zz9000ax-ahi.c")
+        body = source[
+            source.index("case AHIDB_Frequency:"):
+            source.index("case AHIDB_Index:")
+        ]
+        self.assertIn("arg < 0", body)
+        self.assertIn("arg >= ZZ_NUM_FREQS", body)
+        self.assertLess(body.index("arg < 0"), body.index("freqs[arg]"))
+
+    def test_ahi_stop_start_silences_and_resets_ring(self):
+        header = self.read("ahi/driver/zz9000ax-ahi.h")
+        source = self.read("ahi/driver/zz9000ax-ahi.c")
+        stop_body = source[
+            source.index("intAHIsub_Stop"):
+            source.index("static uint32_t __attribute__((used)) intAHIsub_Start")
+        ]
+        start_body = source[
+            source.index("intAHIsub_Start"):
+            source.index("static int32_t __attribute__((used)) intAHIsub_GetAttr")
+        ]
+
+        self.assertIn("uint32_t buf_offset;", header)
+        self.assertIn("static void zero_hw_audio_ring", source)
+        self.assertIn("disable_hw_interrupt(ahi_data);", stop_body)
+        self.assertIn("ahi_data->buf_offset = 0;", stop_body)
+        self.assertIn("zero_hw_audio_ring(ahi_data);", stop_body)
+        self.assertIn("ahi_data->buf_offset = 0;", start_body)
+        self.assertIn("zero_hw_audio_ring(ahi_data);", start_body)
+        self.assertIn("enable_hw_interrupt(ahi_data);", start_body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Move AHI playback-ring position into driver state so Stop/Start can reset it safely.
- Keep AHI hardware interrupts disabled until playback Start, silence the hardware ring before enabling playback, and guard bad AHIDB_Frequency indices.
- Fix MHIGetEmpty to return one completed buffer per call instead of draining multiple played nodes and losing earlier buffer pointers.
- Add repository regression checks for these AHI/MHI behaviors.

## Review
- Local code review found no blocking issues.
- Hardware smoke testing reported no problems on real hardware before PR creation.

## Verification
- python3 -m unittest tools/tests/test_repo_tooling.py
- git diff --check
- make ahi mhi
- tools/check-quality.sh
- tools/check-release.sh --quick

Note: local check-quality skips shellcheck, actionlint, and cppcheck when those tools are not installed locally; GitHub CI covers host checks.