### PR TITLE
fix(net): don't ack empty RX slots (issue #29 drain-boundary frame loss)

### DIFF
--- a/net/ZZNetStats/ZZNetStats.c
+++ b/net/ZZNetStats/ZZNetStats.c
@@ -29,8 +29,8 @@
 
 #include "zz9000_hw.h"
 
-#define ZZNETSTATS_VERSION "2.1"
-#define ZZNETSTATS_DATE    "17.05.2026"
+#define ZZNETSTATS_VERSION "2.2"
+#define ZZNETSTATS_DATE    "30.06.2026"
 
 static const char version[] __attribute__((used)) =
     "$VER: ZZNetStats " ZZNETSTATS_VERSION " (" ZZNETSTATS_DATE ")\r\n";
@@ -133,6 +133,32 @@ int main(int argc, char **argv)
         printf("LastStart.tv_secs    = %lu\n", (unsigned long)stats.LastStart.tv_secs);
         printf("LastStart.tv_micro   = %lu\n", (unsigned long)stats.LastStart.tv_micro);
         print_firmware_rx_stats();
+
+        /* issue #29: device special stats (RxEmptySlot — empty RX slots the
+         * framer skipped instead of acking). Generic printer: shows whatever
+         * records the device supplies, by name. */
+        {
+            UBYTE sbuf[sizeof(struct Sana2SpecialStatHeader) +
+                       8 * sizeof(struct Sana2SpecialStatRecord)];
+            struct Sana2SpecialStatHeader *h = (struct Sana2SpecialStatHeader *)sbuf;
+            struct Sana2SpecialStatRecord *rec =
+                (struct Sana2SpecialStatRecord *)(h + 1);
+            ULONG i;
+
+            memset(sbuf, 0, sizeof(sbuf));
+            h->RecordCountMax        = 8;
+            req->ios2_Req.io_Error   = 0;
+            req->ios2_Req.io_Command = S2_GETSPECIALSTATS;
+            req->ios2_StatData       = h;
+            DoIO((struct IORequest *)req);
+            if (!req->ios2_Req.io_Error) {
+                for (i = 0; i < h->RecordCountSupplied; i++) {
+                    printf("%-20s = %lu\n",
+                           rec[i].String ? (char *)rec[i].String : (char *)"?",
+                           (unsigned long)rec[i].Count);
+                }
+            }
+        }
     }
 
     CloseDevice((struct IORequest *)req);

--- a/net/ZZNetStats/ZZNetStats.c
+++ b/net/ZZNetStats/ZZNetStats.c
@@ -138,8 +138,13 @@ int main(int argc, char **argv)
          * framer skipped instead of acking). Generic printer: shows whatever
          * records the device supplies, by name. */
         {
+            /* Longword-aligned: SANA-II writes ULONG fields through the
+             * header/record pointers, and m68k requires 4-byte alignment
+             * for those accesses. A bare UBYTE[] only guarantees byte
+             * alignment, so force it. */
             UBYTE sbuf[sizeof(struct Sana2SpecialStatHeader) +
-                       8 * sizeof(struct Sana2SpecialStatRecord)];
+                       8 * sizeof(struct Sana2SpecialStatRecord)]
+                __attribute__((aligned(4)));
             struct Sana2SpecialStatHeader *h = (struct Sana2SpecialStatHeader *)sbuf;
             struct Sana2SpecialStatRecord *rec =
                 (struct Sana2SpecialStatRecord *)(h + 1);

--- a/net/device.c
+++ b/net/device.c
@@ -74,6 +74,13 @@ static ULONG ZZ9K_REGS = 0;
 struct Sana2DeviceStats global_stats;
 BOOL is_online;
 
+/* issue #29: count of empty (firmware-cleared) RX slots the framer skipped
+ * instead of acking. Surfaced via S2_GETSPECIALSTATS as "RxEmptySlot".
+ * After this fix it should be large while BadData/Overruns drop to ~0,
+ * confirming the old counts were the empty-slot artifact, not real loss. */
+ULONG rxv_empty_slot = 0;
+#define ZZSS_RX_EMPTY_SLOT 0x5A5A0021UL
+
 /* Staging buffer for RX payload copies.
  *
  * Roadshow's BufferManagement bm_CopyToBuffer is a generic memcpy. When
@@ -623,8 +630,17 @@ SAVEDS VOID DevBeginIO( ASMR(a1) struct IOSana2Req *ioreq       ASMREG(a1),
     break;
   case S2_GETSPECIALSTATS:
     {
+      /* issue #29: expose RxEmptySlot — empty (firmware-cleared) RX slots the
+       * framer skipped instead of acking. ZZNetStats prints it by name. */
       struct Sana2SpecialStatHeader *s2ssh = (struct Sana2SpecialStatHeader *)ioreq->ios2_StatData;
-      if (s2ssh) s2ssh->RecordCountSupplied = 0;
+      if (s2ssh) {
+        struct Sana2SpecialStatRecord *rec =
+            (struct Sana2SpecialStatRecord *)(s2ssh + 1);
+        ULONG max = s2ssh->RecordCountMax;
+        ULONG n = 0;
+        if (n < max) { rec[n].Type = ZZSS_RX_EMPTY_SLOT; rec[n].Count = rxv_empty_slot; rec[n].String = (char*)"RxEmptySlot"; n++; }
+        s2ssh->RecordCountSupplied = n;
+      }
     }
     break;
   default:
@@ -969,6 +985,26 @@ SAVEDS void frame_proc() {
 
     USHORT sz, serial;
     zznet_read_header(frm, &sz, &serial);
+
+    /* issue #29: an all-zero header is an EMPTY (firmware-cleared) slot, not
+     * a frame. The firmware zeroes a slot when it has no frame for it, and a
+     * real frame always has serial >= 1 (frame_serial is pre-incremented, so
+     * 0 is never assigned) and size >= 14. Reading a 0 header happens
+     * routinely at the backlog drain boundary.
+     *
+     * We must NOT ack it (*rx_accept). Doing so races a frame landing in this
+     * same slot between our read and the ack: ethernet_receive_frame would
+     * then consume that real frame (advance + clear the slot) without us ever
+     * reading its payload — a silent inbound loss, invisible to the firmware
+     * (its frames_dropped stays 0). Treat an empty slot exactly like "nothing
+     * new": re-arm the IRQ and wait, leaving old_serial untouched so the next
+     * real frame's gap detection is not poisoned. */
+    if (sz == 0 && serial == 0) {
+      rxv_empty_slot++;
+      *irq_ctrl = 1;
+      recv = Wait(wmask);
+      continue;
+    }
 
     if (serial != old_serial) {
       /* Wire-level sanity check on the HW frame size. Reject frames

--- a/net/device.c
+++ b/net/device.c
@@ -309,6 +309,11 @@ SAVEDS LONG DevOpen( ASMR(a1) struct IOSana2Req *ioreq           ASMREG(a1),
       } else {
 
       memset(&global_stats, 0, sizeof(global_stats));
+      /* Reset the file-scope diagnostic counters alongside global_stats so a
+       * close/reopen presents a consistent baseline: S2_GETGLOBALSTATS starts
+       * from zero here, and S2_GETSPECIALSTATS (RxEmptySlot) must too, else it
+       * would report totals accumulated across previous device sessions. */
+      rxv_empty_slot = 0;
 
       NEWLIST(&db->db_ReadList);
       InitSemaphore(&db->db_ReadListSem);


### PR DESCRIPTION
## Summary

Fixes the large-transfer network stall reported in BlitterStudio/zz9000-firmware#29 (SMB uploads wedging after ~60–350 MB, reproducible across multiple TCP stacks but only on this card).

Root cause is a **drain-boundary consume race** in the RX framer. The framer gated "new frame" on `serial != old_serial` and then issued `*rx_accept` for whatever it read. At the backlog drain boundary it reads a freshly firmware-cleared slot (all-zero header) and acked it. Two harms followed:

1. **Silent inbound frame loss.** When the backlog drains, `frames_backlog_read == frames_backlog_write == R` and the FPGA RX window points at slot `R`. If a real frame lands at slot `R` (the write slot) in the gap between the framer's empty read and its `*rx_accept`, the firmware's `ethernet_receive_frame` sees `frames_backlog == 1` and consumes that real frame — advancing past it and clearing the slot — without the framer ever reading its payload. The loss is invisible to the firmware (`frames_dropped` stays 0), stack-independent, and throughput-dependent: a dropped ACK / SMB response that no stack can recover from indefinitely is what produces the stall.

2. **Counter pollution.** Each empty read also hit the bad-size path (`BadData++`) and set `old_serial = 0`, poisoning the next real frame's gap delta into another `BadData`/`Overruns`. This is why earlier diagnostics saw large `BadData`/`Overruns` that looked like real loss but weren't.

## The fix

An all-zero header is an empty (firmware-cleared) slot, never a frame — real frames always have `serial >= 1` (`frame_serial` is pre-incremented, so 0 is never assigned) and `size >= 14`. Treat it like "nothing new": re-arm the IRQ and wait, do **not** ack, and leave `old_serial` untouched. This closes the consume race and removes the counter poisoning.

A new `RxEmptySlot` special-stat (printed by `ZZNetStats` 2.2) counts the skipped empty slots for verification.

## How it was found

A driver-side re-read probe classified the bad-size headers: of 28,329 such reads, **none** recovered a valid frame on an immediate re-read (`RxHdrRecovered = 0`) and the last bad header was `0x00000000` — proving they were stable-zero empty slots, not torn/raced reads of real frames, and that `BadData`/`Overruns` were the artifact above rather than genuine loss. (Earlier theories of RX payload corruption and cache-coherency were independently ruled out: a per-frame TCP-checksum diagnostic over the bytes the Amiga actually reads showed 1 mismatch in 375,386 frames — the noise floor.)

## Bench verification

Stock v2.2 firmware, fixed `ZZ9000Net.device`:

- Copied a 613 MB ISO **twice back-to-back** (~1.2 GB) — the exact pattern that previously wedged on the second upload — with **no stall**.
- `BadData 56527 → 0`, `Overruns 7132 → 0`, `UnknownTypesReceived 2 → 0`.
- `RxEmptySlot = 231854` (the empty slots now skipped instead of acked).

Both the targeted defect's counter signature going to exactly 0 and the failing scenario reproducing clean confirm the fix.

## Notes

- Driver-only change; no firmware reflash required.
- Optional follow-up (not in this PR): harden `ethernet_receive_frame` firmware-side into a serial/slot handshake rather than a bare advance, so a stray ack can never consume an unread frame.
