### PR TITLE
fix(net): ack RX frames by serial to activate the firmware handshake (issue #29)

### DIFF
--- a/net/device.c
+++ b/net/device.c
@@ -993,8 +993,9 @@ SAVEDS void frame_proc() {
 
     /* issue #29: an all-zero header is an EMPTY (firmware-cleared) slot, not
      * a frame. The firmware zeroes a slot when it has no frame for it, and a
-     * real frame always has serial >= 1 (the firmware's frame_serial counter
-     * skips 0 on its u16 wraparound, so 0 is never assigned to a frame) and
+     * real frame always has serial >= 2 (the firmware's frame_serial counter
+     * skips both 0 and 1 — reserved for the empty-slot sentinel and the
+     * legacy bare-advance ack — so neither is ever assigned to a frame) and
      * size >= 14. Reading a 0 header happens
      * routinely at the backlog drain boundary.
      *
@@ -1058,15 +1059,16 @@ SAVEDS void frame_proc() {
        * stays trustworthy.
        *
        * Unsigned 16-bit subtraction gives the forward distance directly.
-       * The firmware skips serial 0 on its u16 wraparound (0 is the
-       * empty-slot sentinel), so a clean 0xffff→1 step has a raw delta of
-       * 2, not 1. When the serial wrapped (serial < old_serial), discount
-       * that skipped sentinel so the wrap itself is not miscounted as a
-       * dropped frame. */
+       * The firmware skips BOTH serial 0 and 1 on its u16 wraparound (0 is
+       * the empty-slot sentinel, 1 the legacy bare-advance ack), so real
+       * serials run 2..0xffff and a clean 0xffff→2 wrap step has a raw delta
+       * of 3, not 1. When the serial wrapped (serial < old_serial), discount
+       * those two skipped sentinels so the wrap itself is not miscounted as
+       * dropped frames. */
       if (have_baseline) {
         USHORT delta = (USHORT)(serial - old_serial);
-        if (serial < old_serial)   /* wrapped past the skipped-0 sentinel */
-          delta--;
+        if (serial < old_serial)   /* wrapped past the skipped 0 and 1 sentinels */
+          delta -= 2;
         if (delta > 1 && delta <= 128) {
           global_stats.Overruns += (ULONG)(delta - 1);
         } else if (delta > 128) {

--- a/net/device.c
+++ b/net/device.c
@@ -993,8 +993,9 @@ SAVEDS void frame_proc() {
 
     /* issue #29: an all-zero header is an EMPTY (firmware-cleared) slot, not
      * a frame. The firmware zeroes a slot when it has no frame for it, and a
-     * real frame always has serial >= 1 (frame_serial is pre-incremented, so
-     * 0 is never assigned) and size >= 14. Reading a 0 header happens
+     * real frame always has serial >= 1 (the firmware's frame_serial counter
+     * skips 0 on its u16 wraparound, so 0 is never assigned to a frame) and
+     * size >= 14. Reading a 0 header happens
      * routinely at the backlog drain boundary.
      *
      * We must NOT ack it (*rx_accept). Doing so races a frame landing in this
@@ -1056,10 +1057,16 @@ SAVEDS void frame_proc() {
        * genuine miss. Count those separately in BadData so Overruns
        * stays trustworthy.
        *
-       * Unsigned 16-bit subtraction wraps correctly, so delta also
-       * handles the 65535→0 serial rollover. */
+       * Unsigned 16-bit subtraction gives the forward distance directly.
+       * The firmware skips serial 0 on its u16 wraparound (0 is the
+       * empty-slot sentinel), so a clean 0xffff→1 step has a raw delta of
+       * 2, not 1. When the serial wrapped (serial < old_serial), discount
+       * that skipped sentinel so the wrap itself is not miscounted as a
+       * dropped frame. */
       if (have_baseline) {
         USHORT delta = (USHORT)(serial - old_serial);
+        if (serial < old_serial)   /* wrapped past the skipped-0 sentinel */
+          delta--;
         if (delta > 1 && delta <= 128) {
           global_stats.Overruns += (ULONG)(delta - 1);
         } else if (delta > 128) {

--- a/net/device.c
+++ b/net/device.c
@@ -1035,7 +1035,9 @@ SAVEDS void frame_proc() {
         global_stats.BadData++;
         have_baseline = TRUE;
         old_serial    = serial;
-        *rx_accept = 1;
+        /* Ack with the frame's serial so the firmware RX-accept handshake
+         * advances past exactly this (bad) frame and nothing else. */
+        *rx_accept = serial;
         continue;
       }
 
@@ -1102,11 +1104,14 @@ SAVEDS void frame_proc() {
         global_stats.UnknownTypesReceived++;
       }
 
-      /* Release the FPGA RX slot so the next frame can land. We do NOT
-       * re-enable the ethernet IRQ here — staying masked lets us drain
-       * any already-queued frames via the serial recheck on the next
-       * loop iteration without paying for an IRQ we'd ignore anyway. */
-      *rx_accept = 1;
+      /* Release the FPGA RX slot so the next frame can land. We ack with the
+       * frame's own serial so the firmware RX-accept handshake advances past
+       * exactly the frame we just read (a stray ack of an empty/other slot is
+       * rejected firmware-side). We do NOT re-enable the ethernet IRQ here —
+       * staying masked lets us drain any already-queued frames via the serial
+       * recheck on the next loop iteration without paying for an IRQ we'd
+       * ignore anyway. */
+      *rx_accept = serial;
     } else {
       /* Nothing new. Re-enable the ethernet IRQ so the ISR can wake us,
        * then sleep. Enable-before-wait is correct: if a frame raced in


### PR DESCRIPTION
## Summary

Activates the firmware RX-accept serial handshake (BlitterStudio/zz9000-firmware, branch `fix/issue-29-rx-ack-handshake`) for issue #29 defense-in-depth.

**Stacked on #31** (`fix/issue-29-rx-empty-slot`) — it builds on the empty-slot fix and targets that branch; GitHub will retarget it to `master` once #31 merges. Review the last commit (`ack RX frames by serial…`) for the delta.

## Change

Write the consumed frame's serial to the RX-accept register instead of a constant `1`, at both ack sites (the normal delivery path and the bad-size discard path). This lets the firmware verify the ack corresponds to the frame it presented and refuse a stray or empty-slot ack — so a future driver regression can never make the firmware consume an unread frame.

Because the framer no longer acks empty slots (#31), the serial written is always that of a real, presented frame (`serial >= 1`).

## Backward compatibility

Old firmware ignores the ack value and advances regardless, so writing the serial is a no-op there. No false rejections in normal operation: the presented slot's serial is stable between the driver's read and the firmware's ack-processing, and bad-size discards still match (acked == presented for the same slot).

## Build / test

Builds clean (`ZZ9000Net.device`). The handshake pair (this + the firmware PR) is not yet bench-tested; in normal traffic the firmware heartbeat should report `ackrej=0`.
