### PR TITLE
ZZTop: SD-card ZZ9000.CFG Settings window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           docker run --rm -v "$PWD":/src -w /src/ZZTop "$AMIGA_IMAGE" \
             m68k-amigaos-gcc Sources/ZZTop.c ../common/fwup_amiga.c ../common/fwup_client.c \
+              ../common/zzcfg_amiga.c \
               -m68030 -O2 -I../common -I../include -o ZZTop \
               -Wall -Wextra -Wno-unused-parameter -lamiga -noixemul -lm
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           docker run --rm -v "$PWD":/src -w /src/rtg "$AMIGA_IMAGE" \
             m68k-amigaos-gcc mntgfx-gcc.c -m68020 -mtune=68020-60 -O2 \
+              -I../include \
               -o ZZ9000.card -noixemul -Wall -Wextra \
               -Wno-unused-parameter -fomit-frame-pointer \
               -nostartfiles -lamiga

--- a/README.md
+++ b/README.md
@@ -83,6 +83,29 @@ normal AmigaOS file.
 | TLS offload | `amissl_v362.library` | `Libs:AmiSSL/` | AmiSSL 5.27 core with the ZZ9000 crypto-offload provider compiled in; accelerates TLS for all AmiSSL applications. Built per CPU (`68020-40` for 68020/030/040 and `68060`); the installer auto-detects the CPU and installs the matching build. Requires an existing AmiSSL 5.27 install. |
 | Installer | `ZZ9000Installer` | Release zip root | Commodore Installer drawer used for end-user deployment. |
 
+## SD-Card Configuration (ZZ9000.CFG)
+
+Firmware 2.3+ reads an optional `ZZ9000.CFG` file from the root of the
+ZZ9000's FAT32 microSD card at cold boot (documented in the
+[zz9000-firmware README](https://github.com/BlitterStudio/zz9000-firmware#configuration-file-zz9000cfg)).
+ZZTop's **Project → Settings…** window reads and writes it directly
+from AmigaOS, so the card never needs to leave the slot.
+
+The drivers in this repo consult it too:
+
+- `ZZ9000.card` takes its videocap mode and non-standard-vsync
+  defaults from `videocap_mode` / `nonstandard_vsync`.
+- `ZZ9000Net.device`, `zz9000ax.audio` and `mhizz9000.library` honor
+  `int2 = on`; `ZZ9000Net.device` adopts the firmware's `mac`.
+
+Precedence is always: `ENV:` variable (and RTG tooltypes) first, then
+the config file, then the built-in default — so existing setups keep
+working, but a lingering ENV variable also hides the config value.
+Remove the ENV variables (`ZZ9K_INT2`, `ZZ9K_MAC`,
+`ZZ9000-VCAP-800x600`, `ZZ9000-NS-VSYNC[-NTSC]`) when migrating to the
+config file. On firmware older than 2.3 the drivers silently fall back
+to the ENV variables.
+
 ## Command-Line Tools
 
 ### Firmware Updates
@@ -167,6 +190,10 @@ ZZScanlines 3 0
 
 Modes are `0=off`, `1=classic`, `2=soft`, `3=gradient`; parity is
 `0=odd dark`, `1=even dark`.
+
+Like ZZTop's Settings window, `ZZScanlines` changes the live FPGA
+state; to make scanlines survive a power cycle, save them to
+`ZZ9000.CFG` (firmware 2.3+, ZZTop Settings window's Save button).
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ firmware USB stack, scanline V2 controls need the matching bitstream,
 and `zzsd.device` is packed into `BOOT.bin` rather than installed as a
 normal AmigaOS file.
 
+SDK offload services are limited on Zorro 2 boards: the CPU-visible
+shared heap is a small window inside the 4 MB board aperture, which
+only fits the audio/MP3 staging buffers. Audio/MP3 acceleration
+(`mpega.library`, MHI) works on Zorro 2; image decoding
+(`zz9k-picture.datatype`, `zz9k-view`) and crypto offload
+(accelerated `amissl.library`) need Zorro 3 and transparently fall
+back to their software paths on Zorro 2.
+
 ## Components
 
 | Area | Artifact | Installed to | Notes |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,12 @@ from AmigaOS, so the card never needs to leave the slot.
 The drivers in this repo consult it too:
 
 - `ZZ9000.card` takes its videocap mode and non-standard-vsync
-  defaults from `videocap_mode` / `nonstandard_vsync`.
+  defaults from `videocap_mode` / `nonstandard_vsync`. With neither
+  ENV nor config set, native video now defaults to 800x600 @ 60 Hz —
+  the mode most monitors accept, and what the firmware and ZZTop
+  default to (older `ZZ9000.card` versions forced 720x576 @ 50 Hz).
+  PAL-capable setups select `videocap_mode = pal` in ZZTop's Settings
+  window.
 - `ZZ9000Net.device`, `zz9000ax.audio` and `mhizz9000.library` honor
   `int2 = on`; `ZZ9000Net.device` adopts the firmware's `mac`.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ normal AmigaOS file.
 | MHI audio | `mhizz9000.library` | `Libs:MHI/` | Exposes the AX hardware MP3 decoder to MHI-aware players. |
 | USB | `zzusbhw.device` | `Devs:USBHardware/` | Poseidon USB hardware driver. See [usb-poseidon/README.md](usb-poseidon/README.md). |
 | SD boot | `zzsd.device` | Firmware `BOOT.bin` | Size-constrained boot driver for FAT32-hosted HDF boot. See [sd-boot/README.md](sd-boot/README.md). |
-| Configuration | `ZZTop` | `SYS:Tools/` | GUI for resolution, scanlines, hardware toggles, hardware readback, and firmware update/restore. |
+| Configuration | `ZZTop` | `SYS:Tools/` | GUI for hardware readback, firmware update/restore, and the SD-card `ZZ9000.CFG` settings (Project menu > Settings: native video mode, exact refresh, scanlines, INT2, MAC, boot HDF; needs firmware 2.3+). |
 | Scanlines | `ZZScanlines` | `C:` | CLI for scanline V1/V2 modes. |
 | Firmware update | `ZZFwUpdate` | `C:` | Pushes `BOOT.bin` or another root-level file to the ZZ9000 FAT32 microSD card over Zorro. |
 | SDK services | `zz9k.library` | `Libs:` | AmigaOS gateway to the SDK v2 firmware services (image decode, audio, compression, crypto). Built from the pinned [zz9000-sdk](https://github.com/BlitterStudio/zz9000-sdk) ref by `sdk/build.sh`. |
@@ -249,7 +249,7 @@ GitHub release notes are generated automatically.
 | `ZZTop/` | Configuration GUI. |
 | `ZZScanlines/` | Scanline control CLI. |
 | `ZZFwUpdate/` | Firmware/file push CLI using the FWUP protocol. |
-| `common/` | Shared FWUP protocol client (`fwup_client.c`, `fwup_amiga.c`) linked by both `ZZFwUpdate` and `ZZTop`. |
+| `common/` | Shared FWUP protocol client (`fwup_client.c`, `fwup_amiga.c`) and ZZ9000.CFG client (`zzcfg_amiga.c`) linked by `ZZFwUpdate` and `ZZTop`. |
 | `sdk/` | Pulls the pinned zz9000-sdk ref and collects its end-user payloads (libraries, datatype, diagnostics). |
 | `amissl/` | Builds the ZZ9000-accelerated `amissl.library` (adtools toolchain image + zz9000-sdk integration). |
 

--- a/ZZTop/Sources/ZZTop.c
+++ b/ZZTop/Sources/ZZTop.c
@@ -933,7 +933,10 @@ static void settings_save(struct Window *win)
 		settings_set_status(win, "Bad MAC - use aa:bb:cc:dd:ee:ff");
 		return;
 	}
-	if (sv->hdf[0] && !fwup_name_valid(sv->hdf)) {
+	/* Firmware hdf rules, not the FWUP name rules: they differ (no
+	 * leading '.', 63-char cap), and the firmware silently ignores a
+	 * name it rejects at the next cold boot. */
+	if (sv->hdf[0] && !zzcfg_hdf_name_valid(sv->hdf)) {
 		settings_set_status(win, "Bad HDF name (flat root file)");
 		return;
 	}

--- a/ZZTop/Sources/ZZTop.c
+++ b/ZZTop/Sources/ZZTop.c
@@ -796,6 +796,10 @@ static struct Gadget *sgads[SGAD_COUNT];
 static struct zzcfg_values settings_vals;
 static char settings_status_buf[64];
 static char settings_cfg_text[ZZCFG_MAX_SIZE];
+/* ZZ9000.CFG needs firmware ABI 2.3+. On older firmware the window
+ * still opens for the live scanline controls; the config-file fields
+ * and Save/Reload are disabled. */
+static BOOL settings_have_cfg;
 
 static CONST_STRPTR settings_label_samples[] = {
 	(CONST_STRPTR)LABEL_VCAPMODE,
@@ -820,7 +824,10 @@ static CONST_STRPTR settings_value_samples[] = {
 
 static void settings_set_status(struct Window *win, const char *text)
 {
-	snprintf(settings_status_buf, sizeof(settings_status_buf), "%s", text);
+	/* callers may pass settings_status_buf itself - don't self-copy */
+	if (text != settings_status_buf) {
+		snprintf(settings_status_buf, sizeof(settings_status_buf), "%s", text);
+	}
 	if (win && sgads[SGAD_CFG_STATUS]) {
 		GT_SetGadgetAttrs(sgads[SGAD_CFG_STATUS], win, NULL,
 			GTTX_Text, settings_status_buf, TAG_END);
@@ -855,44 +862,49 @@ static void settings_populate(struct Window *win)
 
 	memset(sv, 0, sizeof(*sv));
 
-	v = zzcfg_query(board, ZZ_CFG_KEY_VIDEOCAP_MODE, &present);
-	sv->videocap_pal = (present && v == ZZ_VMODE_720x576) ? 1 : 0;
-
-	v = zzcfg_query(board, ZZ_CFG_KEY_NS_VSYNC, &present);
-	sv->vsync = (present && v <= 2) ? v : 0;
-
 	/* Scanlines reflect the live FPGA state - the config applied it at
 	 * cold boot and this tool/ZZScanlines may have changed it since. */
 	sv->scanline_mode = zz_get_scanline_mode();
 	sv->scanline_parity = zz_get_scanline_parity();
 
-	v = zzcfg_query(board, ZZ_CFG_KEY_INT2, &present);
-	sv->int2 = (present && v) ? 1 : 0;
+	if (settings_have_cfg) {
+		v = zzcfg_query(board, ZZ_CFG_KEY_VIDEOCAP_MODE, &present);
+		sv->videocap_pal = (present && v == ZZ_VMODE_720x576) ? 1 : 0;
 
-	zzcfg_query(board, ZZ_CFG_KEY_MAC_HI, &present);
-	if (present) {
-		UWORD hi = zzcfg_query(board, ZZ_CFG_KEY_MAC_HI, NULL);
-		UWORD mid = zzcfg_query(board, ZZ_CFG_KEY_MAC_MID, NULL);
-		UWORD lo = zzcfg_query(board, ZZ_CFG_KEY_MAC_LO, NULL);
-		snprintf(sv->mac, sizeof(sv->mac), "%02x:%02x:%02x:%02x:%02x:%02x",
-			hi >> 8, hi & 0xff, mid >> 8, mid & 0xff, lo >> 8, lo & 0xff);
-	}
+		v = zzcfg_query(board, ZZ_CFG_KEY_NS_VSYNC, &present);
+		sv->vsync = (present && v <= 2) ? v : 0;
 
-	st = zzcfg_read_raw(board, settings_cfg_text,
-		sizeof(settings_cfg_text), &rawlen);
-	if (st == ZZ_CFG_FILE_OK) {
-		zzcfg_extract_hdf(settings_cfg_text, rawlen, sv->hdf, sizeof(sv->hdf));
-		snprintf(settings_status_buf, sizeof(settings_status_buf),
-			"ZZ9000.CFG: %u bytes on card", (unsigned)rawlen);
-	} else if (st == ZZ_CFG_FILE_NO_FILE) {
-		snprintf(settings_status_buf, sizeof(settings_status_buf),
-			"No ZZ9000.CFG on card yet");
-	} else if (st == ZZ_CFG_FILE_IDLE) {
-		snprintf(settings_status_buf, sizeof(settings_status_buf),
-			"Firmware lacks config support");
+		v = zzcfg_query(board, ZZ_CFG_KEY_INT2, &present);
+		sv->int2 = (present && v) ? 1 : 0;
+
+		zzcfg_query(board, ZZ_CFG_KEY_MAC_HI, &present);
+		if (present) {
+			UWORD hi = zzcfg_query(board, ZZ_CFG_KEY_MAC_HI, NULL);
+			UWORD mid = zzcfg_query(board, ZZ_CFG_KEY_MAC_MID, NULL);
+			UWORD lo = zzcfg_query(board, ZZ_CFG_KEY_MAC_LO, NULL);
+			snprintf(sv->mac, sizeof(sv->mac), "%02x:%02x:%02x:%02x:%02x:%02x",
+				hi >> 8, hi & 0xff, mid >> 8, mid & 0xff, lo >> 8, lo & 0xff);
+		}
+
+		st = zzcfg_read_raw(board, settings_cfg_text,
+			sizeof(settings_cfg_text), &rawlen);
+		if (st == ZZ_CFG_FILE_OK) {
+			zzcfg_extract_hdf(settings_cfg_text, rawlen, sv->hdf, sizeof(sv->hdf));
+			snprintf(settings_status_buf, sizeof(settings_status_buf),
+				"ZZ9000.CFG: %u bytes on card", (unsigned)rawlen);
+		} else if (st == ZZ_CFG_FILE_NO_FILE) {
+			snprintf(settings_status_buf, sizeof(settings_status_buf),
+				"No ZZ9000.CFG on card yet");
+		} else if (st == ZZ_CFG_FILE_IDLE) {
+			snprintf(settings_status_buf, sizeof(settings_status_buf),
+				"Firmware lacks config support");
+		} else {
+			snprintf(settings_status_buf, sizeof(settings_status_buf),
+				"Config read failed (SD error)");
+		}
 	} else {
 		snprintf(settings_status_buf, sizeof(settings_status_buf),
-			"Config read failed (SD error)");
+			"Scanlines only - config needs FW 2.3+");
 	}
 
 	if (!win) return;
@@ -919,6 +931,11 @@ static void settings_save(struct Window *win)
 	struct zzcfg_values *sv = &settings_vals;
 	struct StringInfo *si;
 	UWORD st;
+
+	if (!settings_have_cfg) {
+		settings_set_status(win, "Config needs firmware 2.3+");
+		return;
+	}
 
 	si = (struct StringInfo *)sgads[SGAD_MAC]->SpecialInfo;
 	snprintf(sv->mac, sizeof(sv->mac), "%s", (const char *)si->Buffer);
@@ -1070,14 +1087,7 @@ static VOID settings_window(struct Screen *mysc, void *vi,
 	BOOL done = FALSE;
 	WORD w = 0, h = 0;
 
-	{
-		uint16_t fwrev = zz_get_reg16(REG_ZZ_FW_VERSION);
-		if (fwrev < 0x0203) {
-			errorMessage("ZZ9000.CFG settings need firmware (BOOT.bin) 2.3+.\n"
-				"Update the firmware first.");
-			return;
-		}
-	}
+	settings_have_cfg = (zz_get_reg16(REG_ZZ_FW_VERSION) >= 0x0203);
 
 	if (NULL == settings_create_gadgets(&glist, vi, mainlayout, &w, &h)) {
 		if (glist) FreeGadgets(glist);
@@ -1104,6 +1114,22 @@ static VOID settings_window(struct Screen *mysc, void *vi,
 	}
 
 	settings_populate(win);
+
+	if (!settings_have_cfg) {
+		/* Live scanline controls stay usable on 2.0-2.2 firmware
+		 * (they were on the main window before); everything that
+		 * needs the config-file interface is greyed out. */
+		static const UWORD cfg_only_gadgets[] = {
+			SGAD_VIDEOCAP, SGAD_NSVSYNC, SGAD_INT2,
+			SGAD_MAC, SGAD_HDF, SGAD_BTN_SAVE, SGAD_BTN_RELOAD
+		};
+		size_t i;
+		for (i = 0; i < sizeof(cfg_only_gadgets) / sizeof(cfg_only_gadgets[0]); i++) {
+			GT_SetGadgetAttrs(sgads[cfg_only_gadgets[i]], win, NULL,
+				GA_Disabled, TRUE, TAG_END);
+		}
+	}
+
 	GT_RefreshWindow(win, NULL);
 
 	while (!done) {

--- a/ZZTop/Sources/ZZTop.c
+++ b/ZZTop/Sources/ZZTop.c
@@ -1030,15 +1030,17 @@ static struct Gadget *settings_create_gadgets(struct Gadget **glistptr,
 	ng.ng_TopEdge    = y;
 	ng.ng_GadgetID   = SGAD_MAC;
 	ng.ng_GadgetText = (STRPTR)LABEL_MAC;
+	/* MaxChars includes the trailing NUL (intuition StringInfo), so add
+	 * one or a full 17-char MAC could not be typed. */
 	sgads[SGAD_MAC] = gad = CreateGadget(STRING_KIND, gad, &ng,
-		GTST_MaxChars, ZZCFG_MAC_CHARS, GTST_String, "", TAG_END);
+		GTST_MaxChars, ZZCFG_MAC_CHARS + 1, GTST_String, "", TAG_END);
 	y += l.row_step;
 
 	ng.ng_TopEdge    = y;
 	ng.ng_GadgetID   = SGAD_HDF;
 	ng.ng_GadgetText = (STRPTR)LABEL_HDF;
 	sgads[SGAD_HDF] = gad = CreateGadget(STRING_KIND, gad, &ng,
-		GTST_MaxChars, ZZCFG_HDF_CHARS, GTST_String, "", TAG_END);
+		GTST_MaxChars, ZZCFG_HDF_CHARS + 1, GTST_String, "", TAG_END);
 	y += l.row_step + l.section_gap;
 
 	ng.ng_TopEdge    = y;

--- a/ZZTop/Sources/ZZTop.c
+++ b/ZZTop/Sources/ZZTop.c
@@ -35,13 +35,15 @@
 
 #include "zz9000.h"
 #include "fwup_amiga.h"
+#include "zzcfg_amiga.h"
 
-#define ZZTOP_RELEASE "2.2"
-#define ZZTOP_DATE    "28.06.2026"
+#define ZZTOP_RELEASE "2.3"
+#define ZZTOP_DATE    "09.07.2026"
 
 static const char version[] __attribute__((used)) =
 	"$VER: ZZTop " ZZTOP_RELEASE " (" ZZTOP_DATE ")\r\n";
 
+/* Scanline mode/parity moved to the Settings window (Project menu). */
 #define MYGAD_ZORROVER     (0)
 #define MYGAD_FWVER        (1)
 #define MYGAD_TEMP         (2)
@@ -52,17 +54,32 @@ static const char version[] __attribute__((used)) =
 #define MYGAD_STATUS       (7)
 #define MYGAD_RAWREGS      (8)
 #define MYGAD_LPF          (9)
-#define MYGAD_SCANLINES    (10)
-#define MYGAD_PARITY       (11)
-#define MYGAD_REFRESHMODE  (12)
-#define MYGAD_BTN_TEST     (13)
-#define MYGAD_BTN_REFRESH  (14)
-#define MYGAD_TEST_RESULT  (15)
-#define MYGAD_VIDEOCAP     (16)
-#define MYGAD_BTN_UPDATE   (17)
-#define MYGAD_BTN_RESTORE  (18)
-#define MYGAD_FW_STATUS    (19)
-#define MYGAD_COUNT        (20)
+#define MYGAD_REFRESHMODE  (10)
+#define MYGAD_BTN_TEST     (11)
+#define MYGAD_BTN_REFRESH  (12)
+#define MYGAD_TEST_RESULT  (13)
+#define MYGAD_VIDEOCAP     (14)
+#define MYGAD_BTN_UPDATE   (15)
+#define MYGAD_BTN_RESTORE  (16)
+#define MYGAD_FW_STATUS    (17)
+#define MYGAD_COUNT        (18)
+
+/* Settings window gadgets (own id space, own window). */
+#define SGAD_VIDEOCAP      (0)
+#define SGAD_NSVSYNC       (1)
+#define SGAD_SCANMODE      (2)
+#define SGAD_PARITY        (3)
+#define SGAD_INT2          (4)
+#define SGAD_MAC           (5)
+#define SGAD_HDF           (6)
+#define SGAD_CFG_STATUS    (7)
+#define SGAD_BTN_SAVE      (8)
+#define SGAD_BTN_RELOAD    (9)
+#define SGAD_COUNT         (10)
+
+/* Project menu userdata values. */
+#define MENU_ID_SETTINGS   (1)
+#define MENU_ID_QUIT       (2)
 
 #define LABEL_ZORROVER     "Zorro Version"
 #define LABEL_FWVER        "Firmware ABI"
@@ -78,6 +95,14 @@ static const char version[] __attribute__((used)) =
 #define LABEL_SCANLINES    "Scanlines"
 #define LABEL_PARITY       "Parity"
 #define LABEL_REFRESHMODE  "Auto Refresh"
+#define LABEL_VCAPMODE     "Native Video"
+#define LABEL_NSVSYNC      "Exact Refresh"
+#define LABEL_INT2         "Use INT2"
+#define LABEL_MAC          "MAC Address"
+#define LABEL_HDF          "SD HDF Image"
+#define LABEL_CFG_STATUS   "Config"
+#define LABEL_BTN_SAVE     "Save"
+#define LABEL_BTN_RELOAD   "Reload"
 #define LABEL_TEST_RESULT  "Result"
 #define LABEL_BTN_TEST     "Reg Probe"
 #define LABEL_BTN_REFRESH  "Refresh"
@@ -223,8 +248,6 @@ struct Library* AslBase;
 struct ConfigDev* zz_cd;
 volatile UBYTE* zz_regs;
 int zorro_version = 0;
-uint16_t scanline_mode = 0;
-uint16_t scanline_parity = 0;
 uint16_t refresh_mode = 0;
 double t_min = 0;
 double t_max = 0;
@@ -236,6 +259,20 @@ struct MsgPort *timerport;
 struct Library *TimerBase;
 BOOL timer_pending = FALSE;
 char readout_bufs[MYGAD_COUNT][64];
+
+/* Shared with the Settings window (opened from the Project menu). */
+static struct Screen *zztop_screen;
+static void *zztop_vi;
+static struct ZZTopLayout zztop_layout;
+static struct Menu *zztop_menustrip;
+
+static struct NewMenu zztop_newmenus[] = {
+	{ NM_TITLE, (STRPTR)"Project",     NULL, 0, 0, NULL },
+	{ NM_ITEM,  (STRPTR)"Settings...", (STRPTR)"S", 0, 0, (APTR)MENU_ID_SETTINGS },
+	{ NM_ITEM,  NM_BARLABEL,           NULL, 0, 0, NULL },
+	{ NM_ITEM,  (STRPTR)"Quit",        (STRPTR)"Q", 0, 0, (APTR)MENU_ID_QUIT },
+	{ NM_END,   NULL,                  NULL, 0, 0, NULL }
+};
 
 static WORD zztop_max_word(WORD a, WORD b)
 {
@@ -335,7 +372,7 @@ static void zztop_init_layout(struct ZZTopLayout *layout, struct Screen *screen)
 	y += layout->row_step * 10;
 	y += layout->section_gap;
 	y += layout->slider_step;
-	y += layout->control_step * 3;
+	y += layout->control_step;
 	y += layout->section_gap;
 	y += layout->row_step;
 	y += layout->section_gap;
@@ -734,6 +771,396 @@ static void do_fw_restore(struct Window *win)
 	}
 }
 
+/* ------------------------------------------------------------------ */
+/* Settings window: edits ZZ9000.CFG on the SD card (issue #33).      */
+/* Values load from the firmware's parsed config (cold-boot state)    */
+/* plus the raw file; Save regenerates the file and pushes it over    */
+/* the FWUP path. Scanline changes also apply live, everything else   */
+/* takes effect on the next power cycle.                              */
+/* ------------------------------------------------------------------ */
+
+static STRPTR vcapmode_labels[] = {
+	(STRPTR)"800x600 60Hz",
+	(STRPTR)"PAL 720x576 50Hz",
+	NULL
+};
+
+static STRPTR nsvsync_labels[] = {
+	(STRPTR)"Off",
+	(STRPTR)"PAL ~49.92Hz",
+	(STRPTR)"NTSC",
+	NULL
+};
+
+static struct Gadget *sgads[SGAD_COUNT];
+static struct zzcfg_values settings_vals;
+static char settings_status_buf[64];
+static char settings_cfg_text[ZZCFG_MAX_SIZE];
+
+static CONST_STRPTR settings_label_samples[] = {
+	(CONST_STRPTR)LABEL_VCAPMODE,
+	(CONST_STRPTR)LABEL_NSVSYNC,
+	(CONST_STRPTR)LABEL_SCANLINES,
+	(CONST_STRPTR)LABEL_PARITY,
+	(CONST_STRPTR)LABEL_INT2,
+	(CONST_STRPTR)LABEL_MAC,
+	(CONST_STRPTR)LABEL_HDF,
+	(CONST_STRPTR)LABEL_CFG_STATUS,
+	NULL
+};
+
+static CONST_STRPTR settings_value_samples[] = {
+	(CONST_STRPTR)"PAL 720x576 50Hz",
+	(CONST_STRPTR)"PAL ~49.92Hz",
+	(CONST_STRPTR)"aa:bb:cc:dd:ee:ff",
+	(CONST_STRPTR)"Firmware lacks config support",
+	(CONST_STRPTR)"Saved - power-cycle to apply",
+	NULL
+};
+
+static void settings_set_status(struct Window *win, const char *text)
+{
+	snprintf(settings_status_buf, sizeof(settings_status_buf), "%s", text);
+	if (win && sgads[SGAD_CFG_STATUS]) {
+		GT_SetGadgetAttrs(sgads[SGAD_CFG_STATUS], win, NULL,
+			GTTX_Text, settings_status_buf, TAG_END);
+	}
+}
+
+static int settings_parse_mac(const char *s)
+{
+	int i;
+
+	for (i = 0; i < 6; i++) {
+		int j;
+		for (j = 0; j < 2; j++) {
+			char c = s[i * 3 + j];
+			if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+					(c >= 'A' && c <= 'F')))
+				return 0;
+		}
+		if (i < 5 && s[i * 3 + 2] != ':' && s[i * 3 + 2] != '-')
+			return 0;
+	}
+	return s[ZZCFG_MAC_CHARS] == '\0';
+}
+
+/* Populate settings_vals from the board and push into the gadgets. */
+static void settings_populate(struct Window *win)
+{
+	ULONG board = (ULONG)zz_regs;
+	struct zzcfg_values *sv = &settings_vals;
+	UWORD present = 0;
+	UWORD v, st, rawlen = 0;
+
+	memset(sv, 0, sizeof(*sv));
+
+	v = zzcfg_query(board, ZZ_CFG_KEY_VIDEOCAP_MODE, &present);
+	sv->videocap_pal = (present && v == ZZ_VMODE_720x576) ? 1 : 0;
+
+	v = zzcfg_query(board, ZZ_CFG_KEY_NS_VSYNC, &present);
+	sv->vsync = (present && v <= 2) ? v : 0;
+
+	/* Scanlines reflect the live FPGA state - the config applied it at
+	 * cold boot and this tool/ZZScanlines may have changed it since. */
+	sv->scanline_mode = zz_get_scanline_mode();
+	sv->scanline_parity = zz_get_scanline_parity();
+
+	v = zzcfg_query(board, ZZ_CFG_KEY_INT2, &present);
+	sv->int2 = (present && v) ? 1 : 0;
+
+	zzcfg_query(board, ZZ_CFG_KEY_MAC_HI, &present);
+	if (present) {
+		UWORD hi = zzcfg_query(board, ZZ_CFG_KEY_MAC_HI, NULL);
+		UWORD mid = zzcfg_query(board, ZZ_CFG_KEY_MAC_MID, NULL);
+		UWORD lo = zzcfg_query(board, ZZ_CFG_KEY_MAC_LO, NULL);
+		snprintf(sv->mac, sizeof(sv->mac), "%02x:%02x:%02x:%02x:%02x:%02x",
+			hi >> 8, hi & 0xff, mid >> 8, mid & 0xff, lo >> 8, lo & 0xff);
+	}
+
+	st = zzcfg_read_raw(board, settings_cfg_text,
+		sizeof(settings_cfg_text), &rawlen);
+	if (st == ZZ_CFG_FILE_OK) {
+		zzcfg_extract_hdf(settings_cfg_text, rawlen, sv->hdf, sizeof(sv->hdf));
+		snprintf(settings_status_buf, sizeof(settings_status_buf),
+			"ZZ9000.CFG: %u bytes on card", (unsigned)rawlen);
+	} else if (st == ZZ_CFG_FILE_NO_FILE) {
+		snprintf(settings_status_buf, sizeof(settings_status_buf),
+			"No ZZ9000.CFG on card yet");
+	} else if (st == ZZ_CFG_FILE_IDLE) {
+		snprintf(settings_status_buf, sizeof(settings_status_buf),
+			"Firmware lacks config support");
+	} else {
+		snprintf(settings_status_buf, sizeof(settings_status_buf),
+			"Config read failed (SD error)");
+	}
+
+	if (!win) return;
+
+	GT_SetGadgetAttrs(sgads[SGAD_VIDEOCAP], win, NULL,
+		GTCY_Active, sv->videocap_pal, TAG_END);
+	GT_SetGadgetAttrs(sgads[SGAD_NSVSYNC], win, NULL,
+		GTCY_Active, sv->vsync, TAG_END);
+	GT_SetGadgetAttrs(sgads[SGAD_SCANMODE], win, NULL,
+		GTCY_Active, sv->scanline_mode, TAG_END);
+	GT_SetGadgetAttrs(sgads[SGAD_PARITY], win, NULL,
+		GTCY_Active, sv->scanline_parity, TAG_END);
+	GT_SetGadgetAttrs(sgads[SGAD_INT2], win, NULL,
+		GTCB_Checked, sv->int2 ? TRUE : FALSE, TAG_END);
+	GT_SetGadgetAttrs(sgads[SGAD_MAC], win, NULL,
+		GTST_String, sv->mac, TAG_END);
+	GT_SetGadgetAttrs(sgads[SGAD_HDF], win, NULL,
+		GTST_String, sv->hdf, TAG_END);
+	settings_set_status(win, settings_status_buf);
+}
+
+static void settings_save(struct Window *win)
+{
+	struct zzcfg_values *sv = &settings_vals;
+	struct StringInfo *si;
+	UWORD st;
+
+	si = (struct StringInfo *)sgads[SGAD_MAC]->SpecialInfo;
+	snprintf(sv->mac, sizeof(sv->mac), "%s", (const char *)si->Buffer);
+	si = (struct StringInfo *)sgads[SGAD_HDF]->SpecialInfo;
+	snprintf(sv->hdf, sizeof(sv->hdf), "%s", (const char *)si->Buffer);
+
+	if (sv->mac[0] && !settings_parse_mac(sv->mac)) {
+		settings_set_status(win, "Bad MAC - use aa:bb:cc:dd:ee:ff");
+		return;
+	}
+	if (sv->hdf[0] && !fwup_name_valid(sv->hdf)) {
+		settings_set_status(win, "Bad HDF name (flat root file)");
+		return;
+	}
+
+	settings_set_status(win, "Saving...");
+	st = zzcfg_save((ULONG)zz_regs, sv);
+	if (st == FWUP_OK) {
+		settings_set_status(win, "Saved - power-cycle to apply");
+	} else {
+		snprintf(settings_status_buf, sizeof(settings_status_buf),
+			"Save failed: %s", fwup_strerror(st));
+		settings_set_status(win, settings_status_buf);
+	}
+}
+
+static struct Gadget *settings_create_gadgets(struct Gadget **glistptr,
+	void *vi, const struct ZZTopLayout *mainlayout, WORD *out_w, WORD *out_h)
+{
+	struct NewGadget ng;
+	struct Gadget *gad;
+	struct ZZTopLayout l = *mainlayout;
+	WORD label_width, value_width, y, i;
+
+	/* Same font metrics as the main window, own column widths. */
+	{
+		struct RastPort *rp = zztop_screen ? &zztop_screen->RastPort : NULL;
+		label_width = zztop_max_text_width(rp, settings_label_samples, 8);
+		value_width = zztop_max_text_width(rp, settings_value_samples, 8);
+	}
+	l.gadget_left = l.margin_x + label_width + l.label_gap;
+	l.gadget_width = zztop_max_word(200, value_width + 48);
+
+	gad = CreateContext(glistptr);
+
+	for (i = 0; i < SGAD_COUNT; i++) sgads[i] = NULL;
+
+	y = l.topborder + l.margin_y;
+
+	ng.ng_LeftEdge   = l.gadget_left;
+	ng.ng_TopEdge    = y;
+	ng.ng_Width      = l.gadget_width;
+	ng.ng_Height     = l.gadget_height;
+	ng.ng_TextAttr   = l.text_attr;
+	ng.ng_VisualInfo = vi;
+	ng.ng_Flags      = PLACETEXT_LEFT;
+
+	ng.ng_GadgetID   = SGAD_VIDEOCAP;
+	ng.ng_GadgetText = (STRPTR)LABEL_VCAPMODE;
+	sgads[SGAD_VIDEOCAP] = gad = CreateGadget(CYCLE_KIND, gad, &ng,
+		GTCY_Labels, vcapmode_labels, GTCY_Active, 0, TAG_END);
+	y += l.row_step;
+
+	ng.ng_TopEdge    = y;
+	ng.ng_GadgetID   = SGAD_NSVSYNC;
+	ng.ng_GadgetText = (STRPTR)LABEL_NSVSYNC;
+	sgads[SGAD_NSVSYNC] = gad = CreateGadget(CYCLE_KIND, gad, &ng,
+		GTCY_Labels, nsvsync_labels, GTCY_Active, 0, TAG_END);
+	y += l.row_step;
+
+	ng.ng_TopEdge    = y;
+	ng.ng_GadgetID   = SGAD_SCANMODE;
+	ng.ng_GadgetText = (STRPTR)LABEL_SCANLINES;
+	sgads[SGAD_SCANMODE] = gad = CreateGadget(CYCLE_KIND, gad, &ng,
+		GTCY_Labels, scanline_labels, GTCY_Active, 0, TAG_END);
+	y += l.row_step;
+
+	ng.ng_TopEdge    = y;
+	ng.ng_GadgetID   = SGAD_PARITY;
+	ng.ng_GadgetText = (STRPTR)LABEL_PARITY;
+	sgads[SGAD_PARITY] = gad = CreateGadget(CYCLE_KIND, gad, &ng,
+		GTCY_Labels, parity_labels, GTCY_Active, 0, TAG_END);
+	y += l.row_step;
+
+	ng.ng_TopEdge    = y;
+	ng.ng_GadgetID   = SGAD_INT2;
+	ng.ng_GadgetText = (STRPTR)LABEL_INT2;
+	sgads[SGAD_INT2] = gad = CreateGadget(CHECKBOX_KIND, gad, &ng,
+		GTCB_Checked, FALSE, TAG_END);
+	y += l.row_step;
+
+	ng.ng_TopEdge    = y;
+	ng.ng_GadgetID   = SGAD_MAC;
+	ng.ng_GadgetText = (STRPTR)LABEL_MAC;
+	sgads[SGAD_MAC] = gad = CreateGadget(STRING_KIND, gad, &ng,
+		GTST_MaxChars, ZZCFG_MAC_CHARS, GTST_String, "", TAG_END);
+	y += l.row_step;
+
+	ng.ng_TopEdge    = y;
+	ng.ng_GadgetID   = SGAD_HDF;
+	ng.ng_GadgetText = (STRPTR)LABEL_HDF;
+	sgads[SGAD_HDF] = gad = CreateGadget(STRING_KIND, gad, &ng,
+		GTST_MaxChars, ZZCFG_HDF_CHARS, GTST_String, "", TAG_END);
+	y += l.row_step + l.section_gap;
+
+	ng.ng_TopEdge    = y;
+	ng.ng_GadgetID   = SGAD_CFG_STATUS;
+	ng.ng_GadgetText = (STRPTR)LABEL_CFG_STATUS;
+	sgads[SGAD_CFG_STATUS] = gad = CreateGadget(TEXT_KIND, gad, &ng,
+		GTTX_Text, settings_status_buf, GTTX_Border, TRUE, TAG_END);
+	y += l.row_step + l.section_gap;
+
+	ng.ng_LeftEdge   = l.margin_x;
+	ng.ng_TopEdge    = y;
+	ng.ng_Width      = l.button_width;
+	ng.ng_GadgetID   = SGAD_BTN_SAVE;
+	ng.ng_GadgetText = (STRPTR)LABEL_BTN_SAVE;
+	ng.ng_Flags      = PLACETEXT_IN;
+	sgads[SGAD_BTN_SAVE] = gad = CreateGadget(BUTTON_KIND, gad, &ng,
+		TAG_END);
+
+	ng.ng_LeftEdge   = l.button_col2;
+	ng.ng_GadgetID   = SGAD_BTN_RELOAD;
+	ng.ng_GadgetText = (STRPTR)LABEL_BTN_RELOAD;
+	sgads[SGAD_BTN_RELOAD] = gad = CreateGadget(BUTTON_KIND, gad, &ng,
+		TAG_END);
+	y += l.row_step;
+
+	*out_w = zztop_max_word(l.gadget_left + l.gadget_width + l.margin_x,
+		l.button_col2 + l.button_width + l.margin_x);
+	*out_h = y + l.gadget_height + (l.margin_y / 2);
+
+	for (i = 0; i < SGAD_COUNT; i++) {
+		if (!sgads[i]) return NULL;
+	}
+
+	return gad;
+}
+
+static VOID settings_window(struct Screen *mysc, void *vi,
+	const struct ZZTopLayout *mainlayout)
+{
+	struct Window *win;
+	struct Gadget *glist = NULL;
+	struct IntuiMessage *imsg;
+	struct Gadget *gad;
+	ULONG imsgClass;
+	UWORD imsgCode;
+	BOOL done = FALSE;
+	WORD w = 0, h = 0;
+
+	{
+		uint16_t fwrev = zz_get_reg16(REG_ZZ_FW_VERSION);
+		if (fwrev < 0x0203) {
+			errorMessage("ZZ9000.CFG settings need firmware (BOOT.bin) 2.3+.\n"
+				"Update the firmware first.");
+			return;
+		}
+	}
+
+	if (NULL == settings_create_gadgets(&glist, vi, mainlayout, &w, &h)) {
+		if (glist) FreeGadgets(glist);
+		errorMessage("Settings: gadget creation failed");
+		return;
+	}
+
+	win = OpenWindowTags(NULL,
+		WA_Title,        "ZZ9000 Settings (SD card)",
+		WA_Gadgets,      glist,   WA_AutoAdjust,    TRUE,
+		WA_Width,        w,       WA_MinWidth,      w,
+		WA_InnerHeight,  h,       WA_MinHeight,     h,
+		WA_DragBar,      TRUE,    WA_DepthGadget,   TRUE,
+		WA_Activate,     TRUE,    WA_CloseGadget,   TRUE,
+		WA_SizeGadget,   FALSE,   WA_SimpleRefresh, TRUE,
+		WA_IDCMP, IDCMP_CLOSEWINDOW | IDCMP_REFRESHWINDOW |
+			BUTTONIDCMP | CYCLEIDCMP | CHECKBOXIDCMP | STRINGIDCMP,
+		WA_PubScreen, mysc,
+		TAG_END);
+	if (!win) {
+		FreeGadgets(glist);
+		errorMessage("Settings: OpenWindow() failed");
+		return;
+	}
+
+	settings_populate(win);
+	GT_RefreshWindow(win, NULL);
+
+	while (!done) {
+		Wait(1UL << win->UserPort->mp_SigBit);
+
+		while ((imsg = GT_GetIMsg(win->UserPort))) {
+			gad = (struct Gadget *)imsg->IAddress;
+			imsgClass = imsg->Class;
+			imsgCode = imsg->Code;
+			GT_ReplyIMsg(imsg);
+
+			switch (imsgClass) {
+				case IDCMP_GADGETUP:
+					if (!gad) break;
+					switch (gad->GadgetID) {
+						case SGAD_VIDEOCAP:
+							settings_vals.videocap_pal = imsgCode;
+							break;
+						case SGAD_NSVSYNC:
+							settings_vals.vsync = imsgCode;
+							break;
+						case SGAD_SCANMODE:
+							/* live, like the old main-window control */
+							settings_vals.scanline_mode = imsgCode;
+							zz_set_scanline_mode(imsgCode);
+							break;
+						case SGAD_PARITY:
+							settings_vals.scanline_parity = imsgCode;
+							zz_set_scanline_parity(imsgCode);
+							break;
+						case SGAD_INT2:
+							settings_vals.int2 =
+								(gad->Flags & GFLG_SELECTED) ? 1 : 0;
+							break;
+						case SGAD_BTN_SAVE:
+							settings_save(win);
+							break;
+						case SGAD_BTN_RELOAD:
+							settings_populate(win);
+							break;
+					}
+					break;
+				case IDCMP_CLOSEWINDOW:
+					done = TRUE;
+					break;
+				case IDCMP_REFRESHWINDOW:
+					GT_BeginRefresh(win);
+					GT_EndRefresh(win, TRUE);
+					break;
+			}
+		}
+	}
+
+	CloseWindow(win);
+	FreeGadgets(glist);
+}
+
 VOID handleGadgetEvent(struct Window *win, struct Gadget *gad, ULONG code)
 {
 	if (!gad) return;
@@ -768,22 +1195,6 @@ VOID handleGadgetEvent(struct Window *win, struct Gadget *gad, ULONG code)
 		}
 		case MYGAD_LPF: {
 			zz_set_lpf_freq(code);
-			break;
-		}
-		case MYGAD_SCANLINES: {
-			scanline_mode = (scanline_mode + 1) % SCANLINE_MODE_COUNT;
-			zz_set_scanline_mode(scanline_mode);
-			GT_SetGadgetAttrs(gads[MYGAD_SCANLINES], win, NULL,
-				GTCY_Active, scanline_mode, TAG_END);
-			refresh_zz_info(win);
-			break;
-		}
-		case MYGAD_PARITY: {
-			scanline_parity = (scanline_parity + 1) & 0x1;
-			zz_set_scanline_parity(scanline_parity);
-			GT_SetGadgetAttrs(gads[MYGAD_PARITY], win, NULL,
-				GTCY_Active, scanline_parity, TAG_END);
-			refresh_zz_info(win);
 			break;
 		}
 		case MYGAD_REFRESHMODE: {
@@ -900,26 +1311,6 @@ struct Gadget *createAllGadgets(struct Gadget **glistptr, void *vi, const struct
 	y += layout->slider_step;
 
 	ng.ng_TopEdge	= y;
-	ng.ng_GadgetID	= MYGAD_SCANLINES;
-	ng.ng_GadgetText = (STRPTR)LABEL_SCANLINES;
-
-	gads[MYGAD_SCANLINES] = gad = CreateGadget(CYCLE_KIND, gad, &ng,
-											GTCY_Labels, scanline_labels,
-											GTCY_Active, scanline_mode,
-											TAG_END);
-	y += layout->control_step;
-
-	ng.ng_TopEdge	= y;
-	ng.ng_GadgetID	= MYGAD_PARITY;
-	ng.ng_GadgetText = (STRPTR)LABEL_PARITY;
-
-	gads[MYGAD_PARITY] = gad = CreateGadget(CYCLE_KIND, gad, &ng,
-											GTCY_Labels, parity_labels,
-											GTCY_Active, scanline_parity,
-											TAG_END);
-	y += layout->control_step;
-
-	ng.ng_TopEdge	= y;
 	ng.ng_GadgetID	= MYGAD_REFRESHMODE;
 	ng.ng_GadgetText = (STRPTR)LABEL_REFRESHMODE;
 
@@ -1031,6 +1422,23 @@ VOID process_window_events(struct Window *mywin)
 				case IDCMP_VANILLAKEY:
 					//handleVanillaKey(mywin, imsgCode, slider_level);
 					break;
+				case IDCMP_MENUPICK: {
+					UWORD menuNumber = imsgCode;
+					while (menuNumber != MENUNULL && zztop_menustrip) {
+						struct MenuItem *item = ItemAddress(zztop_menustrip, menuNumber);
+						if (!item) break;
+						switch ((ULONG)GTMENUITEM_USERDATA(item)) {
+							case MENU_ID_SETTINGS:
+								settings_window(zztop_screen, zztop_vi, &zztop_layout);
+								break;
+							case MENU_ID_QUIT:
+								terminated = TRUE;
+								break;
+						}
+						menuNumber = item->NextSelect;
+					}
+					break;
+				}
 				case IDCMP_CLOSEWINDOW:
 					terminated = TRUE;
 					break;
@@ -1053,7 +1461,6 @@ VOID gadtoolsWindow(VOID) {
 	struct Window		*mywin;
 	struct Gadget		*glist = NULL;
 	void						*vi;
-	struct ZZTopLayout layout;
 
 	if (NULL == (mysc = LockPubScreen(NULL)))
 		errorMessage("Couldn't lock default public screen");
@@ -1061,33 +1468,50 @@ VOID gadtoolsWindow(VOID) {
 		if (NULL == (vi = GetVisualInfo(mysc, TAG_END)))
 			errorMessage("GetVisualInfo() failed");
 		else {
-			zztop_init_layout(&layout, mysc);
+			zztop_init_layout(&zztop_layout, mysc);
+			zztop_screen = mysc;
+			zztop_vi = vi;
 
-			if (NULL == createAllGadgets(&glist, vi, &layout))
+			/* Menu strip is optional: without it the tool still works,
+			 * just without the Settings window. */
+			zztop_menustrip = CreateMenus(zztop_newmenus, TAG_END);
+			if (zztop_menustrip &&
+					!LayoutMenus(zztop_menustrip, vi, GTMN_NewLookMenus, TRUE, TAG_END)) {
+				FreeMenus(zztop_menustrip);
+				zztop_menustrip = NULL;
+			}
+
+			if (NULL == createAllGadgets(&glist, vi, &zztop_layout))
 				errorMessage("createAllGadgets() failed");
 			else {
 				if (NULL == (mywin = OpenWindowTags(NULL,
 						WA_Title,			"ZZTop " ZZTOP_RELEASE,
 						WA_Gadgets,		glist,			WA_AutoAdjust,		TRUE,
-						WA_Width,				layout.window_width,			WA_MinWidth,			 layout.window_width,
-						WA_InnerHeight, layout.window_height,			WA_MinHeight,			 layout.window_height,
+						WA_Width,				zztop_layout.window_width,			WA_MinWidth,			 zztop_layout.window_width,
+						WA_InnerHeight, zztop_layout.window_height,			WA_MinHeight,			 zztop_layout.window_height,
 						WA_DragBar,		 TRUE,			WA_DepthGadget,		TRUE,
 						WA_Activate,	 TRUE,			WA_CloseGadget,		TRUE,
 						WA_SizeGadget, FALSE,			WA_SimpleRefresh, TRUE,
 						WA_IDCMP, IDCMP_CLOSEWINDOW | IDCMP_REFRESHWINDOW |
-							IDCMP_VANILLAKEY | SLIDERIDCMP | BUTTONIDCMP |
-							CYCLEIDCMP,
+							IDCMP_VANILLAKEY | IDCMP_MENUPICK | SLIDERIDCMP |
+							BUTTONIDCMP | CYCLEIDCMP,
 						WA_PubScreen, mysc,
 						TAG_END))) {
 					errorMessage("OpenWindow() failed");
 				} else {
+					if (zztop_menustrip) SetMenuStrip(mywin, zztop_menustrip);
 					refresh_zz_info(mywin);
 					GT_RefreshWindow(mywin, NULL);
 					process_window_events(mywin);
+					if (zztop_menustrip) ClearMenuStrip(mywin);
 					CloseWindow(mywin);
 				}
 			}
 
+			if (zztop_menustrip) {
+				FreeMenus(zztop_menustrip);
+				zztop_menustrip = NULL;
+			}
 			if (glist) FreeGadgets(glist);
 			FreeVisualInfo(vi);
 		}
@@ -1124,12 +1548,6 @@ int main(void) {
 
 	zz_regs = (UBYTE*)zz_cd->cd_BoardAddr;
 	CloseLibrary(ExpansionBase);
-
-	/* Sync the controls with whatever mode the FPGA currently holds - the
-	 * V2 bitstream keeps scanline state across soft resets, so a prior
-	 * CLI or ZZTop session may have left a non-zero mode configured. */
-	scanline_mode = zz_get_scanline_mode();
-	scanline_parity = zz_get_scanline_parity();
 
 	if (NULL == (GfxBase = OpenLibrary((CONST_STRPTR)"graphics.library", 37)))
 		errorMessage("Requires V37 graphics.library");

--- a/ZZTop/Sources/ZZTop.c
+++ b/ZZTop/Sources/ZZTop.c
@@ -857,39 +857,26 @@ static void settings_populate(struct Window *win)
 {
 	ULONG board = (ULONG)zz_regs;
 	struct zzcfg_values *sv = &settings_vals;
-	UWORD present = 0;
-	UWORD v, st, rawlen = 0;
+	UWORD st, rawlen = 0;
 
+	/* Editor defaults; keys present in the raw file override them.
+	 * Scanlines default to the live FPGA state - the config applied
+	 * it at cold boot and this tool/ZZScanlines may have changed it
+	 * since. */
 	memset(sv, 0, sizeof(*sv));
-
-	/* Scanlines reflect the live FPGA state - the config applied it at
-	 * cold boot and this tool/ZZScanlines may have changed it since. */
 	sv->scanline_mode = zz_get_scanline_mode();
 	sv->scanline_parity = zz_get_scanline_parity();
 
 	if (settings_have_cfg) {
-		v = zzcfg_query(board, ZZ_CFG_KEY_VIDEOCAP_MODE, &present);
-		sv->videocap_pal = (present && v == ZZ_VMODE_720x576) ? 1 : 0;
-
-		v = zzcfg_query(board, ZZ_CFG_KEY_NS_VSYNC, &present);
-		sv->vsync = (present && v <= 2) ? v : 0;
-
-		v = zzcfg_query(board, ZZ_CFG_KEY_INT2, &present);
-		sv->int2 = (present && v) ? 1 : 0;
-
-		zzcfg_query(board, ZZ_CFG_KEY_MAC_HI, &present);
-		if (present) {
-			UWORD hi = zzcfg_query(board, ZZ_CFG_KEY_MAC_HI, NULL);
-			UWORD mid = zzcfg_query(board, ZZ_CFG_KEY_MAC_MID, NULL);
-			UWORD lo = zzcfg_query(board, ZZ_CFG_KEY_MAC_LO, NULL);
-			snprintf(sv->mac, sizeof(sv->mac), "%02x:%02x:%02x:%02x:%02x:%02x",
-				hi >> 8, hi & 0xff, mid >> 8, mid & 0xff, lo >> 8, lo & 0xff);
-		}
-
 		st = zzcfg_read_raw(board, settings_cfg_text,
 			sizeof(settings_cfg_text), &rawlen);
 		if (st == ZZ_CFG_FILE_OK) {
-			zzcfg_extract_hdf(settings_cfg_text, rawlen, sv->hdf, sizeof(sv->hdf));
+			/* The raw SD file - not the firmware's cold-boot parse
+			 * (REG_ZZ_CONFIG_KEY) - is the editor's source of truth:
+			 * the query would revert values saved or externally
+			 * edited since boot on every Reload, and a subsequent
+			 * Save would then write those stale values back. */
+			zzcfg_parse_text(settings_cfg_text, rawlen, sv);
 			snprintf(settings_status_buf, sizeof(settings_status_buf),
 				"ZZ9000.CFG: %u bytes on card", (unsigned)rawlen);
 		} else if (st == ZZ_CFG_FILE_NO_FILE) {

--- a/ZZTop/build-gcc.sh
+++ b/ZZTop/build-gcc.sh
@@ -9,5 +9,6 @@ fi
 export PATH=/opt/amiga/bin:"$PATH"
 
 m68k-amigaos-gcc Sources/ZZTop.c ../common/fwup_amiga.c ../common/fwup_client.c \
+  ../common/zzcfg_amiga.c \
   -m68030 -O2 -I../common -I../include -o ZZTop \
   -Wall -Wextra -Wno-unused-parameter -lamiga -noixemul -lm

--- a/ahi/README.md
+++ b/ahi/README.md
@@ -119,6 +119,12 @@ it.
 setenv ZZ9K_INT2 1
 ```
 
+With firmware 2.3+ the preferred home for this option is `int2 = on`
+in the SD card's `ZZ9000.CFG` (editable from ZZTop's Settings window),
+which configures AHI, MHI and ZZ9000Net uniformly. An existing
+`ENV:ZZ9K_INT2` variable still takes precedence over the config file,
+so remove the ENV variable when migrating.
+
 ## Troubleshooting
 
 | Symptom                                               | Likely cause / fix |

--- a/ahi/driver/zz9000ax-ahi.c
+++ b/ahi/driver/zz9000ax-ahi.c
@@ -43,6 +43,7 @@
 #include <stdint.h>
 
 #include "zz9000_ax.h"
+#include "zzcfg_query.h"
 #include "zz9000ax-ahi.h"
 
 // Comment out to enable debug output:
@@ -191,9 +192,15 @@ static uint32_t __attribute__((used)) init(BPTR seg_list asm("a0"), struct Libra
   }
 
   BPTR fh;
+  UWORD cfg_present = 0;
   if ((fh=Open((CONST_STRPTR)ZZ_AX_INT2_ENV, MODE_OLDFILE))) {
-    kprintf((CONST_STRPTR)"ZZ9000AX: Using INT2 mode.\n");
+    kprintf((CONST_STRPTR)"ZZ9000AX: Using INT2 mode (ENV).\n");
     Close(fh);
+    Z9AXBase->flags |= ZZ_AX_DEVF_INT2MODE;
+  } else if (zzcfg_query(Z9AXBase->hw_addr, ZZ_CFG_KEY_INT2, &cfg_present) &&
+             cfg_present) {
+    // `int2 = on` in ZZ9000.CFG (firmware 2.3+)
+    kprintf((CONST_STRPTR)"ZZ9000AX: Using INT2 mode (ZZ9000.CFG).\n");
     Z9AXBase->flags |= ZZ_AX_DEVF_INT2MODE;
   } else {
     kprintf((CONST_STRPTR)"ZZ9000AX: Using INT6 mode (default).\n");

--- a/common/zzcfg_amiga.c
+++ b/common/zzcfg_amiga.c
@@ -1,0 +1,187 @@
+/*
+ * Amiga-side client for the ZZ9000.CFG SD-card config file.
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include <exec/types.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "zz9000_hw.h"
+#include "fwup_client.h"
+#include "fwup_amiga.h"
+#include "zzcfg_amiga.h"
+
+/* Matches the FWUP client's poll budget: a raw read is one small FatFs
+ * read, but a slow card under load can still stall for tens of ms. */
+#define ZZCFG_POLL_LIMIT 2000000UL
+
+static volatile UWORD *reg16(ULONG board, ULONG offset)
+{
+    return (volatile UWORD *)(board + offset);
+}
+
+UWORD zzcfg_query(ULONG board, UWORD key, UWORD *present)
+{
+    UWORD value, p;
+
+    *reg16(board, ZZ_REG_CONFIG_KEY) = key;
+    value = *reg16(board, ZZ_REG_CONFIG_KEY);
+    p = *reg16(board, ZZ_REG_CONFIG_PRESENT);
+
+    if (present) *present = p;
+    return value;
+}
+
+UWORD zzcfg_read_raw(ULONG board, char *out, UWORD maxlen, UWORD *outlen)
+{
+    volatile UBYTE *buf = (volatile UBYTE *)(board + ZZ_BUFFER_OFFSET);
+    unsigned long budget = ZZCFG_POLL_LIMIT;
+    UWORD status, len, i;
+
+    *outlen = 0;
+    if (maxlen == 0) return ZZ_CFG_FILE_IO_ERROR;
+    out[0] = '\0';
+
+    /* Reset the handshake, then issue the read. The firmware processes
+     * register writes in bus order, so no wait is needed in between. */
+    *reg16(board, ZZ_REG_CONFIG_FILE) = 0;
+    *reg16(board, ZZ_REG_CONFIG_FILE) = 1;
+
+    do {
+        status = *reg16(board, ZZ_REG_CONFIG_FILE);
+        if (status != ZZ_CFG_FILE_IDLE) break;
+    } while (--budget);
+
+    if (status != ZZ_CFG_FILE_OK) return status;
+
+    len = *reg16(board, ZZ_REG_CONFIG_FILE_LEN);
+    if (len > maxlen - 1) len = maxlen - 1;
+
+    for (i = 0; i < len; i++) {
+        out[i] = (char)buf[i];
+    }
+    out[len] = '\0';
+    *outlen = len;
+    return ZZ_CFG_FILE_OK;
+}
+
+static char zzcfg_lower(char c)
+{
+    return (c >= 'A' && c <= 'Z') ? (char)(c + 32) : c;
+}
+
+static int zzcfg_is_space(char c)
+{
+    return c == ' ' || c == '\t' || c == '\r';
+}
+
+int zzcfg_extract_hdf(const char *text, UWORD len, char *out, UWORD outsz)
+{
+    UWORD pos = 0;
+
+    while (pos < len) {
+        const char *p;
+        UWORD line_end = pos;
+        UWORD n;
+
+        while (line_end < len && text[line_end] != '\n') line_end++;
+
+        /* trim leading whitespace */
+        while (pos < line_end && zzcfg_is_space(text[pos])) pos++;
+        p = &text[pos];
+
+        if (line_end - pos > 4 &&
+                zzcfg_lower(p[0]) == 'h' &&
+                zzcfg_lower(p[1]) == 'd' &&
+                zzcfg_lower(p[2]) == 'f') {
+            UWORD v = pos + 3;
+            while (v < line_end && zzcfg_is_space(text[v])) v++;
+            if (v < line_end && text[v] == '=') {
+                v++;
+                while (v < line_end && zzcfg_is_space(text[v])) v++;
+                n = 0;
+                while (v < line_end && n < outsz - 1 &&
+                        text[v] != '#' && text[v] != ';' &&
+                        !zzcfg_is_space(text[v])) {
+                    out[n++] = text[v++];
+                }
+                out[n] = '\0';
+                if (n > 0) return 1;
+            }
+        }
+
+        pos = line_end + 1;
+    }
+
+    out[0] = '\0';
+    return 0;
+}
+
+UWORD zzcfg_generate(const struct zzcfg_values *v, char *out, UWORD outsz)
+{
+    static const char *vsync_names[] = { "off", "pal", "ntsc" };
+    UWORD vsync = (v->vsync <= 2) ? v->vsync : 0;
+    int n;
+
+    n = snprintf(out, outsz,
+        "# ZZ9000.CFG - ZZ9000 firmware configuration file\n"
+        "# Written by ZZTop. Read once at cold boot (power-on);\n"
+        "# soft resets do not re-read it. See the firmware manual\n"
+        "# for all options: https://github.com/BlitterStudio/zz9000-firmware\n"
+        "\n"
+        "# HDMI output for Amiga native video: 800x600 or pal (720x576 50Hz)\n"
+        "videocap_mode = %s\n"
+        "\n"
+        "# Match the exact Amiga chipset refresh rate: off, pal or ntsc\n"
+        "nonstandard_vsync = %s\n"
+        "\n"
+        "# Scanlines: 0=off 1=classic 2=soft 3=gradient; parity 0/1\n"
+        "scanline_mode = %u\n"
+        "scanline_parity = %u\n"
+        "\n"
+        "# on = drivers use INT2 instead of INT6 (replaces ENV:ZZ9K_INT2)\n"
+        "int2 = %s\n"
+        "\n"
+        "# Ethernet MAC override (replaces ENV:ZZ9K_MAC)\n"
+        "%smac = %s\n"
+        "\n"
+        "# SD-card boot HDF image in the root of the card (default zz9000.hdf)\n"
+        "%shdf = %s\n",
+        v->videocap_pal ? "pal" : "800x600",
+        vsync_names[vsync],
+        (unsigned)(v->scanline_mode & 3),
+        (unsigned)(v->scanline_parity & 1),
+        v->int2 ? "on" : "off",
+        v->mac[0] ? "" : "#", v->mac[0] ? v->mac : "68:82:F2:00:00:01",
+        v->hdf[0] ? "" : "#", v->hdf[0] ? v->hdf : "zz9000.hdf");
+
+    if (n < 0) return 0;
+    if ((UWORD)n >= outsz) return (UWORD)(outsz - 1);
+    return (UWORD)n;
+}
+
+UWORD zzcfg_save(ULONG board, const struct zzcfg_values *v)
+{
+    static char text[ZZCFG_MAX_SIZE];
+    struct fwup_io io;
+    UWORD len, st;
+
+    len = zzcfg_generate(v, text, sizeof(text));
+    if (len == 0) return FWUP_ERR_UNKNOWN;
+
+    fwup_io_init_board(&io, board);
+
+    st = (UWORD)fwup_open(&io, "ZZ9000.CFG");
+    if (st != FWUP_OK) return st;
+
+    st = (UWORD)fwup_write_chunk(&io, text, len);
+    if (st != FWUP_OK) {
+        fwup_abort(&io);
+        return st;
+    }
+
+    st = (UWORD)fwup_close(&io);
+    if (st != FWUP_OK) fwup_abort(&io);
+    return st;
+}

--- a/common/zzcfg_amiga.c
+++ b/common/zzcfg_amiga.c
@@ -64,6 +64,19 @@ static int zzcfg_is_space(char c)
     return c == ' ' || c == '\t' || c == '\r';
 }
 
+int zzcfg_hdf_name_valid(const char *name)
+{
+    UWORD len = 0;
+
+    if (!name || !*name || *name == '.') return 0;
+    for (; *name; name++, len++) {
+        char c = *name;
+        if (c == '/' || c == '\\' || c == ':' || c < 0x21 || c > 0x7e)
+            return 0;
+    }
+    return len <= ZZCFG_HDF_CHARS;
+}
+
 static int zzcfg_str_eq_ci(const char *a, const char *b)
 {
     while (*a && *b) {

--- a/common/zzcfg_amiga.c
+++ b/common/zzcfg_amiga.c
@@ -21,18 +21,6 @@ static volatile UWORD *reg16(ULONG board, ULONG offset)
     return (volatile UWORD *)(board + offset);
 }
 
-UWORD zzcfg_query(ULONG board, UWORD key, UWORD *present)
-{
-    UWORD value, p;
-
-    *reg16(board, ZZ_REG_CONFIG_KEY) = key;
-    value = *reg16(board, ZZ_REG_CONFIG_KEY);
-    p = *reg16(board, ZZ_REG_CONFIG_PRESENT);
-
-    if (present) *present = p;
-    return value;
-}
-
 UWORD zzcfg_read_raw(ULONG board, char *out, UWORD maxlen, UWORD *outlen)
 {
     volatile UBYTE *buf = (volatile UBYTE *)(board + ZZ_BUFFER_OFFSET);

--- a/common/zzcfg_amiga.c
+++ b/common/zzcfg_amiga.c
@@ -64,46 +64,92 @@ static int zzcfg_is_space(char c)
     return c == ' ' || c == '\t' || c == '\r';
 }
 
-int zzcfg_extract_hdf(const char *text, UWORD len, char *out, UWORD outsz)
+static int zzcfg_str_eq_ci(const char *a, const char *b)
+{
+    while (*a && *b) {
+        if (zzcfg_lower(*a) != zzcfg_lower(*b)) return 0;
+        a++; b++;
+    }
+    return *a == *b;
+}
+
+/* Mirrors the firmware parser's line rules: `key = value`, `#`/`;`
+ * comments, case-insensitive keys and keyword values, last value
+ * wins. Only the keys ZZTop edits are decoded; anything else is
+ * skipped (the firmware is the validator of record at cold boot). */
+void zzcfg_parse_text(const char *text, UWORD len, struct zzcfg_values *v)
 {
     UWORD pos = 0;
 
     while (pos < len) {
-        const char *p;
+        char key[24];
+        char value[ZZCFG_HDF_CHARS + 2];
         UWORD line_end = pos;
         UWORD n;
 
         while (line_end < len && text[line_end] != '\n') line_end++;
 
-        /* trim leading whitespace */
+        /* trim leading whitespace, copy the key up to '=' or space */
         while (pos < line_end && zzcfg_is_space(text[pos])) pos++;
-        p = &text[pos];
-
-        if (line_end - pos > 4 &&
-                zzcfg_lower(p[0]) == 'h' &&
-                zzcfg_lower(p[1]) == 'd' &&
-                zzcfg_lower(p[2]) == 'f') {
-            UWORD v = pos + 3;
-            while (v < line_end && zzcfg_is_space(text[v])) v++;
-            if (v < line_end && text[v] == '=') {
-                v++;
-                while (v < line_end && zzcfg_is_space(text[v])) v++;
-                n = 0;
-                while (v < line_end && n < outsz - 1 &&
-                        text[v] != '#' && text[v] != ';' &&
-                        !zzcfg_is_space(text[v])) {
-                    out[n++] = text[v++];
-                }
-                out[n] = '\0';
-                if (n > 0) return 1;
-            }
+        n = 0;
+        while (pos < line_end && n < sizeof(key) - 1 &&
+                text[pos] != '=' && text[pos] != '#' && text[pos] != ';' &&
+                !zzcfg_is_space(text[pos])) {
+            key[n++] = text[pos];
+            pos++;
         }
+        key[n] = '\0';
 
+        while (pos < line_end && zzcfg_is_space(text[pos])) pos++;
+        if (n == 0 || pos >= line_end || text[pos] != '=') {
+            pos = line_end + 1;
+            continue;
+        }
+        pos++; /* skip '=' */
+        while (pos < line_end && zzcfg_is_space(text[pos])) pos++;
+
+        n = 0;
+        while (pos < line_end && n < sizeof(value) - 1 &&
+                text[pos] != '#' && text[pos] != ';' &&
+                !zzcfg_is_space(text[pos])) {
+            value[n++] = text[pos];
+            pos++;
+        }
+        value[n] = '\0';
         pos = line_end + 1;
-    }
+        if (n == 0) continue;
 
-    out[0] = '\0';
-    return 0;
+        if (zzcfg_str_eq_ci(key, "videocap_mode")) {
+            if (zzcfg_str_eq_ci(value, "pal") ||
+                    zzcfg_str_eq_ci(value, "720x576"))
+                v->videocap_pal = 1;
+            else if (zzcfg_str_eq_ci(value, "800x600"))
+                v->videocap_pal = 0;
+        } else if (zzcfg_str_eq_ci(key, "nonstandard_vsync")) {
+            if (zzcfg_str_eq_ci(value, "off")) v->vsync = 0;
+            else if (zzcfg_str_eq_ci(value, "pal") ||
+                     zzcfg_str_eq_ci(value, "on")) v->vsync = 1;
+            else if (zzcfg_str_eq_ci(value, "ntsc")) v->vsync = 2;
+        } else if (zzcfg_str_eq_ci(key, "scanline_mode")) {
+            if (value[1] == '\0' && value[0] >= '0' && value[0] <= '3')
+                v->scanline_mode = (UWORD)(value[0] - '0');
+        } else if (zzcfg_str_eq_ci(key, "scanline_parity")) {
+            if (value[1] == '\0' && (value[0] == '0' || value[0] == '1'))
+                v->scanline_parity = (UWORD)(value[0] - '0');
+        } else if (zzcfg_str_eq_ci(key, "int2")) {
+            if (zzcfg_str_eq_ci(value, "on") || zzcfg_str_eq_ci(value, "1"))
+                v->int2 = 1;
+            else if (zzcfg_str_eq_ci(value, "off") ||
+                     zzcfg_str_eq_ci(value, "0"))
+                v->int2 = 0;
+        } else if (zzcfg_str_eq_ci(key, "mac")) {
+            if (strlen(value) < sizeof(v->mac))
+                strcpy(v->mac, value);
+        } else if (zzcfg_str_eq_ci(key, "hdf")) {
+            if (strlen(value) < sizeof(v->hdf))
+                strcpy(v->hdf, value);
+        }
+    }
 }
 
 UWORD zzcfg_generate(const struct zzcfg_values *v, char *out, UWORD outsz)

--- a/common/zzcfg_amiga.c
+++ b/common/zzcfg_amiga.c
@@ -73,6 +73,11 @@ int zzcfg_hdf_name_valid(const char *name)
         char c = *name;
         if (c == '/' || c == '\\' || c == ':' || c < 0x21 || c > 0x7e)
             return 0;
+        /* '#' and ';' start comments in the config parser, so a name
+         * containing them would save fine and then silently truncate
+         * at the next cold-boot parse (hdf = disk#1.hdf -> "disk"). */
+        if (c == '#' || c == ';')
+            return 0;
     }
     return len <= ZZCFG_HDF_CHARS;
 }

--- a/common/zzcfg_amiga.h
+++ b/common/zzcfg_amiga.h
@@ -40,11 +40,12 @@ struct zzcfg_values {
 UWORD zzcfg_read_raw(ULONG board, char *out, UWORD maxlen, UWORD *outlen);
 
 /* Is `name` a valid `hdf = ...` value? Mirrors the firmware's
- * hdf_name_valid rules (zz_config.c), which differ from the FWUP
- * destination-name rules: printable ASCII except '/', '\' and ':',
- * no leading '.', 1..ZZCFG_HDF_CHARS characters. Validate with this
- * before saving or the firmware will silently ignore the key at the
- * next cold boot. */
+ * hdf_name_valid rules (zz_config.c): printable ASCII except '/',
+ * '\' and ':', no leading '.', 1..ZZCFG_HDF_CHARS characters —
+ * additionally rejecting '#' and ';', which the config parsers treat
+ * as comment starts and would silently truncate the name at the next
+ * cold-boot parse. Validate with this before saving; these rules
+ * differ from the FWUP destination-name rules. */
 int zzcfg_hdf_name_valid(const char *name);
 
 /* Decode the ZZTop-editable keys from raw config text into v, using

--- a/common/zzcfg_amiga.h
+++ b/common/zzcfg_amiga.h
@@ -1,0 +1,80 @@
+/*
+ * Amiga-side client for the ZZ9000.CFG SD-card config file.
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Reads the firmware's parsed config values (ZZ_REG_CONFIG_KEY query),
+ * fetches the raw file (ZZ_REG_CONFIG_FILE + shared buffer), generates
+ * a fresh commented config from a value set, and writes it back over
+ * the FWUP file-push path. Firmware >= 2.2 (issue #33). Used by ZZTop's
+ * Settings window.
+ */
+#ifndef ZZCFG_AMIGA_H
+#define ZZCFG_AMIGA_H
+
+#include <exec/types.h>
+#include <stdint.h>
+
+/* Matches the firmware's boot-time parse cap (ZZ_CONFIG_MAX_SIZE). */
+#define ZZCFG_MAX_SIZE   4096
+#define ZZCFG_MAC_CHARS  17          /* aa:bb:cc:dd:ee:ff */
+#define ZZCFG_HDF_CHARS  63
+
+/* Key ids for zzcfg_query (mirror firmware zz_config.h). */
+#define ZZ_CFG_KEY_LOADED          0
+#define ZZ_CFG_KEY_VIDEOCAP_MODE   1
+#define ZZ_CFG_KEY_NS_VSYNC        2
+#define ZZ_CFG_KEY_SCANLINE_MODE   3
+#define ZZ_CFG_KEY_SCANLINE_PARITY 4
+#define ZZ_CFG_KEY_INT2            5
+#define ZZ_CFG_KEY_MAC_HI          6
+#define ZZ_CFG_KEY_MAC_MID         7
+#define ZZ_CFG_KEY_MAC_LO          8
+
+/* zzcfg_read_raw statuses (mirror firmware zz_config_file_status). */
+#define ZZ_CFG_FILE_OK           0
+#define ZZ_CFG_FILE_NO_FILE      1
+#define ZZ_CFG_FILE_IO_ERROR     2
+#define ZZ_CFG_FILE_IDLE         0xFFFF
+
+/* enum zz_video_modes values the config interface deals in. */
+#define ZZ_VMODE_800x600         1
+#define ZZ_VMODE_720x576         6
+
+/* Everything ZZTop's Settings window edits. mac/hdf are C strings;
+ * an empty string means "not configured" and is emitted as a
+ * commented-out example line. */
+struct zzcfg_values {
+    UWORD videocap_pal;      /* 0 = 800x600 60Hz, 1 = PAL 720x576 50Hz */
+    UWORD vsync;             /* 0 = off, 1 = pal, 2 = ntsc */
+    UWORD scanline_mode;     /* 0-3 */
+    UWORD scanline_parity;   /* 0-1 */
+    UWORD int2;              /* 0-1 */
+    char  mac[ZZCFG_MAC_CHARS + 3];
+    char  hdf[ZZCFG_HDF_CHARS + 5];
+};
+
+/* Query one parsed config value from the firmware. *present is set to
+ * 1 if the key was given in ZZ9000.CFG (for ZZ_CFG_KEY_LOADED: whether
+ * the file was found at cold boot). */
+UWORD zzcfg_query(ULONG board, UWORD key, UWORD *present);
+
+/* Fetch the raw file contents into out (NUL-terminated, maxlen must be
+ * >= 1). Returns a ZZ_CFG_FILE_* status; *outlen is the byte count.
+ * ZZ_CFG_FILE_IDLE means the firmware never answered (no support). */
+UWORD zzcfg_read_raw(ULONG board, char *out, UWORD maxlen, UWORD *outlen);
+
+/* Scan raw config text for a `hdf = name` line (comments stripped,
+ * case-insensitive key). Returns 1 and copies the name if found. */
+int zzcfg_extract_hdf(const char *text, UWORD len, char *out, UWORD outsz);
+
+/* Render a fresh, fully commented ZZ9000.CFG from v. Returns the byte
+ * count (always < ZZCFG_MAX_SIZE for any input). */
+UWORD zzcfg_generate(const struct zzcfg_values *v, char *out, UWORD outsz);
+
+/* Generate and push the file to the SD card as ZZ9000.CFG via FWUP.
+ * Returns an FWUP status (FWUP_OK on success). The previous file is
+ * kept as ZZ9000.bak by the firmware. */
+UWORD zzcfg_save(ULONG board, const struct zzcfg_values *v);
+
+#endif /* ZZCFG_AMIGA_H */

--- a/common/zzcfg_amiga.h
+++ b/common/zzcfg_amiga.h
@@ -39,6 +39,14 @@ struct zzcfg_values {
  * ZZ_CFG_FILE_IDLE means the firmware never answered (no support). */
 UWORD zzcfg_read_raw(ULONG board, char *out, UWORD maxlen, UWORD *outlen);
 
+/* Is `name` a valid `hdf = ...` value? Mirrors the firmware's
+ * hdf_name_valid rules (zz_config.c), which differ from the FWUP
+ * destination-name rules: printable ASCII except '/', '\' and ':',
+ * no leading '.', 1..ZZCFG_HDF_CHARS characters. Validate with this
+ * before saving or the firmware will silently ignore the key at the
+ * next cold boot. */
+int zzcfg_hdf_name_valid(const char *name);
+
 /* Decode the ZZTop-editable keys from raw config text into v, using
  * the firmware parser's line rules (comments, case-insensitive keys,
  * last value wins). Keys absent from the text leave v untouched, so

--- a/common/zzcfg_amiga.h
+++ b/common/zzcfg_amiga.h
@@ -39,9 +39,14 @@ struct zzcfg_values {
  * ZZ_CFG_FILE_IDLE means the firmware never answered (no support). */
 UWORD zzcfg_read_raw(ULONG board, char *out, UWORD maxlen, UWORD *outlen);
 
-/* Scan raw config text for a `hdf = name` line (comments stripped,
- * case-insensitive key). Returns 1 and copies the name if found. */
-int zzcfg_extract_hdf(const char *text, UWORD len, char *out, UWORD outsz);
+/* Decode the ZZTop-editable keys from raw config text into v, using
+ * the firmware parser's line rules (comments, case-insensitive keys,
+ * last value wins). Keys absent from the text leave v untouched, so
+ * pre-fill v with the desired defaults. This is what makes the raw
+ * SD file — not the firmware's boot-time parse — the editor's source
+ * of truth: values saved or externally edited after boot survive a
+ * Reload instead of being reverted to the cold-boot state. */
+void zzcfg_parse_text(const char *text, UWORD len, struct zzcfg_values *v);
 
 /* Render a fresh, fully commented ZZ9000.CFG from v. Returns the byte
  * count (always < ZZCFG_MAX_SIZE for any input). */

--- a/common/zzcfg_amiga.h
+++ b/common/zzcfg_amiga.h
@@ -14,32 +14,12 @@
 
 #include <exec/types.h>
 #include <stdint.h>
+#include "zzcfg_query.h"   /* key ids, statuses, inline zzcfg_query() */
 
 /* Matches the firmware's boot-time parse cap (ZZ_CONFIG_MAX_SIZE). */
 #define ZZCFG_MAX_SIZE   4096
 #define ZZCFG_MAC_CHARS  17          /* aa:bb:cc:dd:ee:ff */
 #define ZZCFG_HDF_CHARS  63
-
-/* Key ids for zzcfg_query (mirror firmware zz_config.h). */
-#define ZZ_CFG_KEY_LOADED          0
-#define ZZ_CFG_KEY_VIDEOCAP_MODE   1
-#define ZZ_CFG_KEY_NS_VSYNC        2
-#define ZZ_CFG_KEY_SCANLINE_MODE   3
-#define ZZ_CFG_KEY_SCANLINE_PARITY 4
-#define ZZ_CFG_KEY_INT2            5
-#define ZZ_CFG_KEY_MAC_HI          6
-#define ZZ_CFG_KEY_MAC_MID         7
-#define ZZ_CFG_KEY_MAC_LO          8
-
-/* zzcfg_read_raw statuses (mirror firmware zz_config_file_status). */
-#define ZZ_CFG_FILE_OK           0
-#define ZZ_CFG_FILE_NO_FILE      1
-#define ZZ_CFG_FILE_IO_ERROR     2
-#define ZZ_CFG_FILE_IDLE         0xFFFF
-
-/* enum zz_video_modes values the config interface deals in. */
-#define ZZ_VMODE_800x600         1
-#define ZZ_VMODE_720x576         6
 
 /* Everything ZZTop's Settings window edits. mac/hdf are C strings;
  * an empty string means "not configured" and is emitted as a
@@ -53,11 +33,6 @@ struct zzcfg_values {
     char  mac[ZZCFG_MAC_CHARS + 3];
     char  hdf[ZZCFG_HDF_CHARS + 5];
 };
-
-/* Query one parsed config value from the firmware. *present is set to
- * 1 if the key was given in ZZ9000.CFG (for ZZ_CFG_KEY_LOADED: whether
- * the file was found at cold boot). */
-UWORD zzcfg_query(ULONG board, UWORD key, UWORD *present);
 
 /* Fetch the raw file contents into out (NUL-terminated, maxlen must be
  * >= 1). Returns a ZZ_CFG_FILE_* status; *outlen is the byte count.

--- a/include/zz9000_hw.h
+++ b/include/zz9000_hw.h
@@ -79,6 +79,18 @@
 #define ZZ_REG_AUDIO_CONFIG      0xF4
 #define ZZ_REG_DEBUG             0xFC
 
+/* Feature toggles (write ZZ_REG_USER1 = feature id, then the value here). */
+#define ZZ_REG_USER1             0x40
+#define ZZ_REG_SET_FEATURE       0x60
+#define ZZ_CARD_FEATURE_NONSTANDARD_VSYNC 2
+
+/* ZZ9000.CFG interface (firmware >= 2.3, issue #33). Key ids, file
+ * statuses and the client API live in common/zzcfg_amiga.h. */
+#define ZZ_REG_CONFIG_KEY        0xE8
+#define ZZ_REG_CONFIG_PRESENT    0xEA
+#define ZZ_REG_CONFIG_FILE       0xEC
+#define ZZ_REG_CONFIG_FILE_LEN   0xEE
+
 #define ZZ_SCANLINE_MODE_REG     0x100C
 #define ZZ_SCANLINE_PARITY_REG   0x100E
 

--- a/include/zzcfg_query.h
+++ b/include/zzcfg_query.h
@@ -1,0 +1,64 @@
+/*
+ * Header-only ZZ9000.CFG value query (firmware ABI >= 2.3, issue #33).
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Self-contained so device drivers (net/ahi/mhi) can consult the
+ * SD-card config without linking the full common/zzcfg_amiga.c client
+ * or pulling in proto headers. On firmware older than 2.3 the register
+ * group reads as zero, so every key reports "absent" and callers fall
+ * back to their ENV: variables - no version check needed.
+ */
+#ifndef ZZCFG_QUERY_H
+#define ZZCFG_QUERY_H
+
+#include <exec/types.h>
+
+#ifndef ZZ_REG_CONFIG_KEY
+#define ZZ_REG_CONFIG_KEY        0xE8
+#define ZZ_REG_CONFIG_PRESENT    0xEA
+#define ZZ_REG_CONFIG_FILE       0xEC
+#define ZZ_REG_CONFIG_FILE_LEN   0xEE
+#endif
+
+/* Key ids (mirror firmware zz_config.h). */
+#define ZZ_CFG_KEY_LOADED          0
+#define ZZ_CFG_KEY_VIDEOCAP_MODE   1
+#define ZZ_CFG_KEY_NS_VSYNC        2
+#define ZZ_CFG_KEY_SCANLINE_MODE   3
+#define ZZ_CFG_KEY_SCANLINE_PARITY 4
+#define ZZ_CFG_KEY_INT2            5
+#define ZZ_CFG_KEY_MAC_HI          6
+#define ZZ_CFG_KEY_MAC_MID         7
+#define ZZ_CFG_KEY_MAC_LO          8
+
+/* ZZ_REG_CONFIG_FILE statuses (mirror firmware zz_config_file_status). */
+#define ZZ_CFG_FILE_OK           0
+#define ZZ_CFG_FILE_NO_FILE      1
+#define ZZ_CFG_FILE_IO_ERROR     2
+#define ZZ_CFG_FILE_IDLE         0xFFFF
+
+/* enum zz_video_modes values the config interface deals in. */
+#define ZZ_VMODE_800x600         1
+#define ZZ_VMODE_720x576         6
+
+/* Query one parsed ZZ9000.CFG value. *present is set to 1 if the key
+ * was given in the config file (for ZZ_CFG_KEY_LOADED: whether the
+ * file was found at cold boot); the value reads as 0 when absent. */
+static inline UWORD zzcfg_query(ULONG board, UWORD key, UWORD *present)
+{
+    volatile UWORD *key_reg =
+        (volatile UWORD *)(board + ZZ_REG_CONFIG_KEY);
+    volatile UWORD *present_reg =
+        (volatile UWORD *)(board + ZZ_REG_CONFIG_PRESENT);
+    UWORD value, p;
+
+    *key_reg = key;
+    value = *key_reg;
+    p = *present_reg;
+
+    if (present) *present = p;
+    return value;
+}
+
+#endif /* ZZCFG_QUERY_H */

--- a/installer/README.md
+++ b/installer/README.md
@@ -79,7 +79,10 @@ The SDK runtime payloads (`zz9k.library`, the ARM-accelerated
 `mpega.library` drop-in, the `zz9k-picture.datatype` plus its inactive
 JPEG/PNG descriptors under `Storage/DataTypes`, and the `zz9k-#?` CLI
 tools) are built from the pinned zz9000-sdk ref and populated by CI.
-They need the SDK-service ZZ9000 firmware to do anything useful.
+They need the SDK-service ZZ9000 firmware to do anything useful. On
+Zorro 2 boards only the audio/MP3 offload is accelerated — image
+decoding and crypto offload need the Zorro 3 board window and fall
+back to software there (the installer prompts say so too).
 
 When installing the ZZ9000-accelerated `amissl.library`, the installer
 first backs up the stock `LIBS:AmiSSL/amissl_v362.library` to

--- a/installer/ZZ9000Installer/Install ZZ9000
+++ b/installer/ZZ9000Installer/Install ZZ9000
@@ -366,8 +366,8 @@
 ; --------------------------------------------------------------------
 
 (if (exists "Libs/zz9k.library")
-   (if (askbool (prompt "Install the ZZ9000 SDK runtime?\n\nzz9k.library (firmware services), an ARM-accelerated mpega.library drop-in, and the zz9k-picture.datatype.\n\nRequires the SDK-service ZZ9000 firmware.")
-                (help "zz9k.library is the AmigaOS gateway to the ZZ9000's firmware services (image decode, audio, compression, crypto). mpega.library is a drop-in replacement that decodes MP3 on the ZZ9000's ARM cores. zz9k-picture.datatype accelerates picture decoding; its JPEG/PNG descriptors are staged inactive under SYS:Storage/DataTypes for explicit opt-in."))
+   (if (askbool (prompt "Install the ZZ9000 SDK runtime?\n\nzz9k.library (firmware services), an ARM-accelerated mpega.library drop-in, and the zz9k-picture.datatype.\n\nRequires the SDK-service ZZ9000 firmware.\n\nNote for Zorro 2 boards: only the audio/MP3 offload (mpega.library, MHI) is accelerated. Image decoding and crypto offload need the larger Zorro 3 board window and fall back to software on Zorro 2.")
+                (help "zz9k.library is the AmigaOS gateway to the ZZ9000's firmware services (image decode, audio, compression, crypto). mpega.library is a drop-in replacement that decodes MP3 on the ZZ9000's ARM cores. zz9k-picture.datatype accelerates picture decoding; its JPEG/PNG descriptors are staged inactive under SYS:Storage/DataTypes for explicit opt-in. On Zorro 2 the CPU-visible shared heap is a small window that only fits the audio/MP3 staging buffers, so image-decode and crypto services are not accelerated there."))
       (
          (set #newver   (getversion "Libs/zz9k.library"))
          (set #newmajor (/ #newver 65536))
@@ -437,8 +437,8 @@
 (if (OR (exists "Libs/AmiSSL/68020-40/amissl_v362.library")
         (exists "Libs/AmiSSL/68060/amissl_v362.library"))
    (if (exists "LIBS:AmiSSL/amissl_v362.library")
-       (if (askbool (prompt "Install the ZZ9000-accelerated amissl.library?\n\nThis replaces LIBS:AmiSSL/amissl_v362.library with a build that offloads TLS cryptography (handshakes and AES-GCM/ChaCha20 records) to the ZZ9000. Without the board or its crypto firmware it behaves exactly like stock AmiSSL.\n\nThe original is backed up to amissl_v362.library.bak before it is replaced.")
-                    (help "A drop-in AmiSSL 5.27 core library with the ZZ9000 crypto-offload provider compiled in: every AmiSSL application (browsers, mail clients) gets hardware-accelerated TLS with no changes. The combined binary is GPLv3; sources are public in the BlitterStudio zz9000-sdk repository."))
+       (if (askbool (prompt "Install the ZZ9000-accelerated amissl.library?\n\nThis replaces LIBS:AmiSSL/amissl_v362.library with a build that offloads TLS cryptography (handshakes and AES-GCM/ChaCha20 records) to the ZZ9000. Without the board or its crypto firmware it behaves exactly like stock AmiSSL.\n\nNote: the crypto offload needs a Zorro 3 board window; on Zorro 2 boards this library behaves exactly like stock AmiSSL (no acceleration, no harm).\n\nThe original is backed up to amissl_v362.library.bak before it is replaced.")
+                    (help "A drop-in AmiSSL 5.27 core library with the ZZ9000 crypto-offload provider compiled in: every AmiSSL application (browsers, mail clients) gets hardware-accelerated TLS with no changes. On Zorro 2 the offload path is unavailable (the CPU-visible shared window is too small for crypto payloads) and the library transparently uses the stock software path. The combined binary is GPLv3; sources are public in the BlitterStudio zz9000-sdk repository."))
            (
               ; Pick the CPU build exactly as AmiSSL's own installer does: default
               ; to the 68060 build when the OS reports a 68060, or 68060.library /

--- a/installer/ZZ9000Installer/Install ZZ9000
+++ b/installer/ZZ9000Installer/Install ZZ9000
@@ -135,16 +135,8 @@
 ; Scandoubler cap (ZZ9000-VCAP)
 ; --------------------------------------------------------------------
 
-(if (askbool (prompt "Does your monitor support 50 Hz modes? Say No to create ENVARC:ZZ9000-VCAP-800x600, which switches the scandoubler to 60 Hz.")
-             (help "The default scandoubler output is 720x576 @ 50 Hz. Saying No creates the 60 Hz flag. With firmware 2.3+ this can also live as videocap_mode in ZZ9000.CFG on the SD card (editable in ZZTop's Settings window); the ENV variable overrides the config file when both exist."))
-    (delete "ENVARC:ZZ9000-VCAP-800x600"
-       (prompt "Remove any existing 800x600 / 60 Hz flag.")
-       (help ""))
-    (textfile
-       (prompt "Creating ENVARC:ZZ9000-VCAP-800x600")
-       (help "")
-       (append "1")
-       (dest "ENVARC:ZZ9000-VCAP-800x600")))
+(message "Native (chipset) video is shown on HDMI as 800x600 @ 60 Hz by default - the mode most monitors accept.\n\nIf your monitor supports 50 Hz, you can switch to native 720x576 @ 50 Hz afterwards in ZZTop's Settings window (videocap_mode = pal in ZZ9000.CFG on the SD card, firmware 2.3+).\n\nNote: a leftover ENVARC:ZZ9000-VCAP-800x600 variable overrides the config file; delete it if you use the Settings window."
+   (help "Older driver versions defaulted to 720x576 @ 50 Hz and used ENVARC:ZZ9000-VCAP-800x600 to switch to 60 Hz. The 60 Hz mode is now the default, so the flag is only kept for older drivers."))
 
 (complete 50)
 

--- a/installer/ZZ9000Installer/Install ZZ9000
+++ b/installer/ZZ9000Installer/Install ZZ9000
@@ -136,7 +136,7 @@
 ; --------------------------------------------------------------------
 
 (if (askbool (prompt "Does your monitor support 50 Hz modes? Say No to create ENVARC:ZZ9000-VCAP-800x600, which switches the scandoubler to 60 Hz.")
-             (help "The default scandoubler output is 720x576 @ 50 Hz. Saying No creates the 60 Hz flag."))
+             (help "The default scandoubler output is 720x576 @ 50 Hz. Saying No creates the 60 Hz flag. With firmware 2.3+ this can also live as videocap_mode in ZZ9000.CFG on the SD card (editable in ZZTop's Settings window); the ENV variable overrides the config file when both exist."))
     (delete "ENVARC:ZZ9000-VCAP-800x600"
        (prompt "Remove any existing 800x600 / 60 Hz flag.")
        (help ""))
@@ -229,7 +229,7 @@
    (
       (set #mac (askstring
          (prompt "Enter your unique Ethernet MAC address (printed in your ZZ9000 manual). Only the last six hex digits need to change.")
-         (help "To change the MAC later, edit ENVARC:ZZ9K_MAC.")
+         (help "To change the MAC later, edit ENVARC:ZZ9K_MAC. With firmware 2.3+ it can also live as mac in ZZ9000.CFG on the SD card (ZZTop's Settings window); the ENV variable overrides the config file when both exist.")
          (default "68:82:f2:01:02:00")))
 
       (textfile

--- a/mhi/mhizz9000.c
+++ b/mhi/mhizz9000.c
@@ -40,6 +40,7 @@
 #include <devices/timer.h>
 
 #include "zz9000_ax.h"
+#include "zzcfg_query.h"
 #include "mhizz9000.h"
 
 #include "zz9k/audio.h"
@@ -224,8 +225,13 @@ BOOL UserLibInit(struct MHI_LibBase *MhiLibBase) {
 	MhiLibBase->hw_size = hw_size;
 
 	BPTR fh;
+	UWORD cfg_present = 0;
 	if((fh=Open((CONST_STRPTR)ZZ_AX_INT2_ENV, MODE_OLDFILE))) {
 		Close(fh);
+		MhiLibBase->flags |= ZZ_AX_DEVF_INT2MODE;
+	} else if (zzcfg_query(hw_addr, ZZ_CFG_KEY_INT2, &cfg_present) &&
+			cfg_present) {
+		// `int2 = on` in ZZ9000.CFG (firmware 2.3+)
 		MhiLibBase->flags |= ZZ_AX_DEVF_INT2MODE;
 	}
 

--- a/net/Makefile
+++ b/net/Makefile
@@ -19,6 +19,7 @@ SOURCES = deviceheader.c deviceinit.c device.c
 CFLAGS  = -m$(CPU) -mtune=68020-60 -msoft-float -O2 \
           -Wall -Wextra -Wno-unused-parameter -Wno-pointer-sign \
           -fomit-frame-pointer \
+          -I../include \
           -DDEVICENAME=$(DEVICEID) \
           -DHAVE_VERSION_H
 

--- a/net/device.c
+++ b/net/device.c
@@ -64,6 +64,7 @@ const struct NSDeviceQueryResult NSDQueryAnswer = {
 #endif /* DEVICES_NEWSTYLE_H */
 
 #include "device.h"
+#include "zzcfg_query.h"
 #include "macros.h"
 
 // FIXME get rid of global var!
@@ -268,13 +269,7 @@ SAVEDS struct Device *DevInit( ASMR(d0) DEVBASEP                  ASMREG(d0),
           D(("ZZ9000Net: MNT ZZ9000 found.\n"));
           ZZ9K_REGS = (ULONG)cd->cd_BoardAddr;
 
-          // Thanks to https://grandcentrix.team
-          HW_MAC[0]=0x68;
-          HW_MAC[1]=0x82;
-          HW_MAC[2]=0xF2;
-          HW_MAC[3]=0x00;
-          HW_MAC[4]=0x01;
-          HW_MAC[5]=0x00;
+          BOOL have_env_mac = FALSE;
 
           if ((fh=Open("ENV:ZZ9K_MAC",MODE_OLDFILE))) {
             UBYTE char_buf[32];
@@ -284,16 +279,35 @@ SAVEDS struct Device *DevInit( ASMR(d0) DEVBASEP                  ASMREG(d0),
             } else {
               D(("ZZ9000Net: Setting MAC address from ENV:ZZ9K_MAC.\n"));
               set_mac_from_string(char_buf);
+              have_env_mac = TRUE;
             }
             Close(fh);
           }
 
-          // FIXME
-          *(volatile USHORT*)(ZZ9K_REGS+0x84) = (HW_MAC[0]<<8)|HW_MAC[1];
-          *(volatile USHORT*)(ZZ9K_REGS+0x84) = (HW_MAC[0]<<8)|HW_MAC[1];
-          *(volatile USHORT*)(ZZ9K_REGS+0x86) = (HW_MAC[2]<<8)|HW_MAC[3];
-          *(volatile USHORT*)(ZZ9K_REGS+0x86) = (HW_MAC[2]<<8)|HW_MAC[3];
-          *(volatile USHORT*)(ZZ9K_REGS+0x88) = (HW_MAC[4]<<8)|HW_MAC[5];
+          if (have_env_mac) {
+            // ENV override wins: push it into the firmware
+            // FIXME
+            *(volatile USHORT*)(ZZ9K_REGS+0x84) = (HW_MAC[0]<<8)|HW_MAC[1];
+            *(volatile USHORT*)(ZZ9K_REGS+0x84) = (HW_MAC[0]<<8)|HW_MAC[1];
+            *(volatile USHORT*)(ZZ9K_REGS+0x86) = (HW_MAC[2]<<8)|HW_MAC[3];
+            *(volatile USHORT*)(ZZ9K_REGS+0x86) = (HW_MAC[2]<<8)|HW_MAC[3];
+            *(volatile USHORT*)(ZZ9K_REGS+0x88) = (HW_MAC[4]<<8)|HW_MAC[5];
+          } else {
+            // Adopt the firmware's current MAC instead of forcing the
+            // old built-in default: honors a `mac` line in ZZ9000.CFG
+            // (applied at cold boot, firmware 2.3+) and reads back the
+            // same 68:82:F2:00:01:00 default otherwise.
+            USHORT mac_hi  = *(volatile USHORT*)(ZZ9K_REGS+0x84);
+            USHORT mac_mid = *(volatile USHORT*)(ZZ9K_REGS+0x86);
+            USHORT mac_lo  = *(volatile USHORT*)(ZZ9K_REGS+0x88);
+            HW_MAC[0] = mac_hi >> 8;
+            HW_MAC[1] = mac_hi & 0xff;
+            HW_MAC[2] = mac_mid >> 8;
+            HW_MAC[3] = mac_mid & 0xff;
+            HW_MAC[4] = mac_lo >> 8;
+            HW_MAC[5] = mac_lo & 0xff;
+            D(("ZZ9000Net: Using firmware MAC.\n"));
+          }
 
           ok = 1;
 
@@ -321,9 +335,15 @@ SAVEDS struct Device *DevInit( ASMR(d0) DEVBASEP                  ASMREG(d0),
 
 	{
 		BPTR fh;
+		UWORD cfg_present = 0;
 		if ((fh=Open("ENV:ZZ9K_INT2",MODE_OLDFILE))) {
-			D(("ZZ9000Net: Using INT2 mode.\n"));
+			D(("ZZ9000Net: Using INT2 mode (ENV).\n"));
 			Close(fh);
+			db->db_Flags |= DEVF_INT2MODE;
+		} else if (ok && ZZ9K_REGS &&
+				zzcfg_query(ZZ9K_REGS, ZZ_CFG_KEY_INT2, &cfg_present) && cfg_present) {
+			// `int2 = on` in ZZ9000.CFG (firmware 2.3+)
+			D(("ZZ9000Net: Using INT2 mode (ZZ9000.CFG).\n"));
 			db->db_Flags |= DEVF_INT2MODE;
 		} else {
 			D(("ZZ9000Net: Using INT6 mode (default).\n"));

--- a/rtg/build.sh
+++ b/rtg/build.sh
@@ -8,4 +8,4 @@ fi
 
 export PATH=/opt/amiga/bin:"$PATH"
 
-m68k-amigaos-gcc mntgfx-gcc.c -m68020 -mtune=68020-60 -O2 -o ZZ9000.card -noixemul -Wall -Wextra -Wno-unused-parameter -fomit-frame-pointer -nostartfiles -lamiga
+m68k-amigaos-gcc mntgfx-gcc.c -m68020 -mtune=68020-60 -O2 -I../include -o ZZ9000.card -noixemul -Wall -Wextra -Wno-unused-parameter -fomit-frame-pointer -nostartfiles -lamiga

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -33,6 +33,7 @@
 
 #include "mntgfx-gcc.h"
 #include "zz9000.h"
+#include "zzcfg_query.h"
 #include "blitter_cache.h"
 
 #define STR(s) #s
@@ -690,11 +691,32 @@ int __attribute__((used)) FindCard(__REGA0(struct BoardInfo* b)) {
 		}
 
 		MNTZZ9KRegs* registers = (MNTZZ9KRegs *)b->RegisterBase;
-		b->CardData[ZZ_CARD_DATA_SCANDBL_800X600] = env_flag_exists(DOSBase, "ENV:ZZ9000-VCAP-800x600");
-		if (env_flag_exists(DOSBase, "ENV:ZZ9000-NS-VSYNC"))
+		UWORD cfg_present = 0;
+		UWORD cfg_value;
+
+		/* Precedence: ENV variable, then ZZ9000.CFG (firmware 2.3+;
+		 * the query reports "absent" on older firmware), then the
+		 * built-in default. Without this the unconditional re-apply
+		 * below would clobber the config file's cold-boot values. */
+		if (env_flag_exists(DOSBase, "ENV:ZZ9000-VCAP-800x600")) {
+			b->CardData[ZZ_CARD_DATA_SCANDBL_800X600] = 1;
+		} else {
+			cfg_value = zzcfg_query((ULONG)b->RegisterBase,
+				ZZ_CFG_KEY_VIDEOCAP_MODE, &cfg_present);
+			b->CardData[ZZ_CARD_DATA_SCANDBL_800X600] =
+				(cfg_present && cfg_value == ZZ_VMODE_800x600) ? 1 : 0;
+		}
+
+		if (env_flag_exists(DOSBase, "ENV:ZZ9000-NS-VSYNC")) {
 			b->CardData[ZZ_CARD_DATA_NSVSYNC] = 1;
-		else if (env_flag_exists(DOSBase, "ENV:ZZ9000-NS-VSYNC-NTSC"))
+		} else if (env_flag_exists(DOSBase, "ENV:ZZ9000-NS-VSYNC-NTSC")) {
 			b->CardData[ZZ_CARD_DATA_NSVSYNC] = 2;
+		} else {
+			cfg_value = zzcfg_query((ULONG)b->RegisterBase,
+				ZZ_CFG_KEY_NS_VSYNC, &cfg_present);
+			if (cfg_present && cfg_value <= 2)
+				b->CardData[ZZ_CARD_DATA_NSVSYNC] = cfg_value;
+		}
 
 		apply_vcap_settings(registers, (LONG)b->CardData[ZZ_CARD_DATA_SCANDBL_800X600]);
 		apply_nonstandard_vsync_settings(registers, (LONG)b->CardData[ZZ_CARD_DATA_NSVSYNC]);

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -697,14 +697,21 @@ int __attribute__((used)) FindCard(__REGA0(struct BoardInfo* b)) {
 		/* Precedence: ENV variable, then ZZ9000.CFG (firmware 2.3+;
 		 * the query reports "absent" on older firmware), then the
 		 * built-in default. Without this the unconditional re-apply
-		 * below would clobber the config file's cold-boot values. */
+		 * below would clobber the config file's cold-boot values.
+		 *
+		 * The default with neither ENV nor config is now 800x600
+		 * 60 Hz - the monitor-compatible choice, and what the
+		 * firmware, ZZTop and a freshly generated ZZ9000.CFG all
+		 * default to. Older ZZ9000.card versions forced 720x576
+		 * 50 Hz here; PAL-capable setups select it explicitly with
+		 * `videocap_mode = pal` (ZZTop Settings) or the tooltype. */
 		if (env_flag_exists(DOSBase, "ENV:ZZ9000-VCAP-800x600")) {
 			b->CardData[ZZ_CARD_DATA_SCANDBL_800X600] = 1;
 		} else {
 			cfg_value = zzcfg_query((ULONG)b->RegisterBase,
 				ZZ_CFG_KEY_VIDEOCAP_MODE, &cfg_present);
 			b->CardData[ZZ_CARD_DATA_SCANDBL_800X600] =
-				(cfg_present && cfg_value == ZZ_VMODE_800x600) ? 1 : 0;
+				(cfg_present && cfg_value == ZZ_VMODE_720x576) ? 0 : 1;
 		}
 
 		if (env_flag_exists(DOSBase, "ENV:ZZ9000-NS-VSYNC")) {

--- a/sd-boot/README.md
+++ b/sd-boot/README.md
@@ -15,7 +15,10 @@ RDB-partitioned contents as bootable volumes.
 ## What you need
 
 * An SD card formatted as **FAT32** (not ExFAT).
-* A file named exactly `/zz9000.hdf` at the root of that card.
+* A file named exactly `/zz9000.hdf` at the root of that card
+  (firmware 2.3+ can boot a different root-level image via a
+  `hdf = name.hdf` line in `ZZ9000.CFG`, editable from ZZTop's
+  Settings window).
 * The HDF must use **Amiga RDB partitioning** — the first 16 blocks
   must contain an `RDSK` block pointing at one or more `PART` blocks
   plus `FSHD`/`LSEG` entries for any custom filesystems (PFS3, SFS,


### PR DESCRIPTION
Companion to BlitterStudio/zz9000-firmware#47 (issue BlitterStudio/zz9000-firmware#33). SDK-side counterpart: BlitterStudio/zz9000-sdk#12.

## What this does

Adds a **Project menu** to ZZTop with a **Settings…** window that reads and writes the firmware's `ZZ9000.CFG` on the SD card directly from AmigaOS — no more pulling the card to edit boot-time options — and migrates every driver in this repo from `ENV:`-only settings to the config file.

| Setting | Config key | Applies |
|---|---|---|
| Native Video (800x600 / PAL 720x576) | `videocap_mode` | RTG driver at load; next power cycle otherwise |
| Exact Refresh (Off / PAL ~49.92Hz / NTSC) | `nonstandard_vsync` | RTG driver at load; next power cycle otherwise |
| Scanlines + Parity | `scanline_mode` / `scanline_parity` | **live** + persisted |
| Use INT2 | `int2` | net/AHI/MHI drivers at load |
| MAC Address | `mac` | firmware at cold boot; net driver adopts it |
| SD HDF Image | `hdf` | next power cycle |

**Behavior change:** with neither ENV variable nor config key set, ZZ9000.card no longer forces native video to 720x576@50 - the default is now 800x600@60 (the mode most monitors accept, matching the firmware and ZZTop defaults). PAL-capable setups select `videocap_mode = pal` in ZZTop Settings or the `VCAP=PAL` tooltype.

The scanline/parity cycles move from the main window into the Settings window, so live control and persistence live in one place (previously scanlines reset on every power cycle). On firmware older than 2.3 the window still opens with the live scanline controls; the config-file fields and Save/Reload are disabled.

## How it works

- **Load**: parsed values come from the firmware's `REG_ZZ_CONFIG_KEY` query interface; the raw file is fetched via the `REG_ZZ_CONFIG_FILE` command (staged in the shared buffer) to extract the `hdf` name and show file status. Scanlines populate from the live FPGA registers.
- **Save**: regenerates a fully commented `ZZ9000.CFG` and pushes it through the existing FWUP file-push path, so the firmware keeps the previous file as `ZZ9000.bak`. MAC and HDF names are validated before writing.
- **Driver wiring**: new header-only `include/zzcfg_query.h` (no libc, no proto headers) lets drivers read parsed config values. Precedence is always ENV: variable (and RTG tooltypes) → config key → default; on pre-2.3 firmware the register group reads as zero so everything falls back to ENV automatically.
  - `ZZ9000.card` takes vcap/vsync defaults from the config instead of clobbering them with ENV-derived defaults at init.
  - `ZZ9000Net.device` adopts the firmware's current MAC when `ENV:ZZ9K_MAC` is absent (instead of forcing the built-in default over a config-applied one) and honors `int2`.
  - `zz9000ax.audio` / `mhizz9000.library` honor `int2`.
- **Docs/installer**: new "SD-Card Configuration" section in the README, per-component README updates (ahi, sd-boot, ZZScanlines note), and the installer's VCAP/MAC prompts now mention the config alternative and ENV precedence.
- Shared client `common/zzcfg_amiga.c/h` next to the FWUP client it reuses.

## Testing

- All components build clean (gcc `-Wall -Wextra`, no new warnings): ZZTop, ZZ9000.card, ZZ9000Net.device, zz9000ax.audio, mhizz9000.library.
- Not yet hardware-tested: needs a card running firmware 2.3 (merged zz9000-firmware#47) — bench validation of the load/save round-trip and the int2/mac/vcap driver paths recommended before merge.