### PR TITLE
Enable P96 off-screen bitmaps in card VRAM (Zorro 3)

### DIFF
--- a/include/zzcfg_query.h
+++ b/include/zzcfg_query.h
@@ -31,6 +31,7 @@
 #define ZZ_CFG_KEY_MAC_HI          6
 #define ZZ_CFG_KEY_MAC_MID         7
 #define ZZ_CFG_KEY_MAC_LO          8
+#define ZZ_CFG_KEY_OFFSCREEN_BITMAPS 9
 
 /* ZZ_REG_CONFIG_FILE statuses (mirror firmware zz_config_file_status). */
 #define ZZ_CFG_FILE_OK           0

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -1852,6 +1852,8 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 			case ABMA_RGBFormat: rgbformat = tag->ti_Data; break;
 			case ABMA_NoMemory: return NULL;
 			case ABMA_ConstantBytesPerRow: bytesperrow_override = tag->ti_Data; break;
+			/* ABMA_Clear needs no handling: the firmware zero-fills
+			 * every surface it allocates */
 			default: break;
 		}
 		tag++;
@@ -1860,8 +1862,17 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 	if (!zz_rgbformat_bytes_per_pixel(rgbformat))
 		return NULL;
 
-	uint16_t bytesperrow = bytesperrow_override ? bytesperrow_override :
-		CalculateBytesPerRow(b, NULL, width, height, rgbformat);
+	uint16_t bytesperrow;
+	if (bytesperrow_override) {
+		/* P96 demands this exact stride; refuse what the blitter
+		 * cannot step (pitches are programmed as BytesPerRow >> 2) */
+		if (bytesperrow_override & (ZZ_OFFSCREEN_PITCH_ALIGN - 1))
+			return NULL;
+		bytesperrow = bytesperrow_override;
+	} else {
+		bytesperrow = zz_offscreen_pad_pitch(
+			CalculateBytesPerRow(b, NULL, width, height, rgbformat));
+	}
 	uint32_t size = (uint32_t)bytesperrow * height;
 	if (!size) return NULL;
 

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -35,6 +35,7 @@
 #include "zz9000.h"
 #include "zzcfg_query.h"
 #include "blitter_cache.h"
+#include "offscreen_bitmap.h"
 
 #define STR(s) #s
 #define XSTR(s) STR(s)
@@ -118,6 +119,7 @@ char dummies[128];
 #define ZZ_CARD_DATA_MONITOR_SWITCH 3
 #define ZZ_CARD_DATA_DISPLAY_ENABLED 4
 #define ZZ_CARD_DATA_SECONDARY_PALETTE 5
+#define ZZ_CARD_DATA_OFFSCREEN_BITMAPS 6
 #define MNT_MANUFACTURER 0x6d6e
 #define ZZ9000_PRODUCT_Z2 0x3
 #define ZZ9000_PRODUCT_Z3 0x4
@@ -647,6 +649,7 @@ int __attribute__((used)) FindCard(__REGA0(struct BoardInfo* b)) {
 	b->CardData[ZZ_CARD_DATA_MONITOR_SWITCH] = 1;
 	b->CardData[ZZ_CARD_DATA_DISPLAY_ENABLED] = 1;
 	b->CardData[ZZ_CARD_DATA_SECONDARY_PALETTE] = 0;
+	b->CardData[ZZ_CARD_DATA_OFFSCREEN_BITMAPS] = 1;
 	if ((cd = find_unconfigured_configdev(ExpansionBase, MNT_MANUFACTURER, ZZ9000_PRODUCT_Z3))) zorro_version = 3;
 	else if ((cd = find_unconfigured_configdev(ExpansionBase, MNT_MANUFACTURER, ZZ9000_PRODUCT_Z2))) zorro_version = 2;
 
@@ -731,6 +734,15 @@ int __attribute__((used)) FindCard(__REGA0(struct BoardInfo* b)) {
 				ZZ_CFG_KEY_NS_VSYNC, &cfg_present);
 			if (cfg_present && cfg_value <= 2)
 				b->CardData[ZZ_CARD_DATA_NSVSYNC] = cfg_value;
+		}
+
+		if (env_flag_exists(DOSBase, "ENV:ZZ9000-NO-OFFSCREEN")) {
+			b->CardData[ZZ_CARD_DATA_OFFSCREEN_BITMAPS] = 0;
+		} else {
+			cfg_value = zzcfg_query((ULONG)b->RegisterBase,
+				ZZ_CFG_KEY_OFFSCREEN_BITMAPS, &cfg_present);
+			if (cfg_present)
+				b->CardData[ZZ_CARD_DATA_OFFSCREEN_BITMAPS] = (cfg_value != 0);
 		}
 
 		apply_vcap_settings(registers, (LONG)b->CardData[ZZ_CARD_DATA_SCANDBL_800X600]);
@@ -833,9 +845,21 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 	//b->SetDPMSLevel = (void *)NULL;
 	//b->ResetChip = (void *)NULL;
 	//b->GetFeatureAttrs = (void *)NULL;
-	//b->AllocBitMap = (void *)ZZ_AllocBitMap;
-	//b->FreeBitMap = (void *)ZZ_FreeBitMap;
-	//b->GetBitMapAttr = (void *)NULL;
+	/* Off-screen bitmaps in card VRAM (Z3 only; ZZ_AllocBitMap refuses
+	 * on Z2). Kill switch: ENV:ZZ9000-NO-OFFSCREEN, the ZZ9000.CFG
+	 * offscreen_bitmaps key (both read in FindCard), or the
+	 * OFFSCREENBITMAPS tooltype, which wins over both. */
+	{
+		BOOL offscreen = (BOOL)b->CardData[ZZ_CARD_DATA_OFFSCREEN_BITMAPS];
+		const char *value = tooltype_value(tool_types, "OFFSCREENBITMAPS");
+		if (value)
+			offscreen = !value_is_false(value);
+		if (offscreen && (b->CardFlags & CARDFLAG_ZORRO_3)) {
+			b->AllocBitMap = (void *)ZZ_AllocBitMap;
+			b->FreeBitMap = (void *)ZZ_FreeBitMap;
+			b->GetBitMapAttr = (void *)ZZ_GetBitMapAttr;
+		}
+	}
 
 	b->SetSprite = (void *)SetSprite;
 	b->SetSpritePosition = (void *)SetSpritePosition;
@@ -1789,6 +1813,28 @@ void DrawLine(__REGA0(struct BoardInfo *b), __REGA1(struct RenderInfo *r), __REG
 	}
 }
 
+/* Off-screen bitmaps we place in card VRAM. `bm` must stay the first
+ * member so the struct BitMap* P96 hands back is also a ZZBitMap*;
+ * magic + the Planes[0] range check tell ours apart from foreign
+ * (system RAM / planar) bitmaps. */
+struct ZZBitMap {
+	struct BitMap bm;
+	ULONG magic;
+	ULONG card_offset;
+	ULONG rgbformat;
+	UWORD width, height;
+};
+
+static struct ZZBitMap *zz_bitmap_ours(struct BoardInfo *b, struct BitMap *bm) {
+	struct ZZBitMap *zbm = (struct ZZBitMap *)bm;
+
+	if (!bm || !zz_offscreen_is_ours(zbm->magic, (uint32_t)bm->Planes[0],
+			(uint32_t)b->MemoryBase, (uint32_t)b->MemorySize))
+		return NULL;
+
+	return zbm;
+}
+
 struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width), __REGD1(ULONG height), __REGA1(struct TagItem *tags)) {
 	if (!(b->CardFlags & CARDFLAG_ZORRO_3))
 		return NULL;
@@ -1811,6 +1857,9 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 		tag++;
 	}
 
+	if (!zz_rgbformat_bytes_per_pixel(rgbformat))
+		return NULL;
+
 	uint16_t bytesperrow = bytesperrow_override ? bytesperrow_override :
 		CalculateBytesPerRow(b, NULL, width, height, rgbformat);
 	uint32_t size = (uint32_t)bytesperrow * height;
@@ -1824,36 +1873,74 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 	uint32_t card_offset = gfxdata->offset[0];
 	if (!card_offset) return NULL;
 
-	struct BitMap *bm = (struct BitMap *)AllocMem(sizeof(struct BitMap), MEMF_PUBLIC | MEMF_CLEAR);
-	if (!bm) {
+	struct ZZBitMap *zbm = (struct ZZBitMap *)AllocMem(sizeof(struct ZZBitMap), MEMF_PUBLIC | MEMF_CLEAR);
+	if (!zbm) {
 		gfxdata->offset[0] = card_offset;
 		gfxdata->u8_user[0] = 0;
 		zzwrite16(&registers->blitter_acc_op, ACC_OP_FREE_SURFACE);
 		return NULL;
 	}
 
-	bm->BytesPerRow = bytesperrow;
-	bm->Rows = height;
-	bm->Depth = 1;
-	bm->Planes[0] = (PLANEPTR)((uint32_t)b->MemoryBase + card_offset);
+	zbm->bm.BytesPerRow = bytesperrow;
+	zbm->bm.Rows = height;
+	zbm->bm.Depth = (UBYTE)zz_rgbformat_bits_per_pixel(rgbformat);
+	zbm->bm.Planes[0] = (PLANEPTR)((uint32_t)b->MemoryBase + card_offset);
+	zbm->magic = ZZ_OFFSCREEN_MAGIC;
+	zbm->card_offset = card_offset;
+	zbm->rgbformat = rgbformat;
+	zbm->width = width;
+	zbm->height = height;
 
-	return bm;
+	return &zbm->bm;
 }
 
 BOOL ZZ_FreeBitMap(__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGA2(struct TagItem *tags)) {
-	if (!bm) return FALSE;
+	struct ZZBitMap *zbm = zz_bitmap_ours(b, bm);
+	if (!zbm) return FALSE;
 
 	if (b->CardFlags & CARDFLAG_ZORRO_3) {
 		MNTZZ9KRegs* registers = (MNTZZ9KRegs*)b->RegisterBase;
-		uint32_t card_offset = (uint32_t)bm->Planes[0] - (uint32_t)b->MemoryBase;
 		dmy_cache
-		gfxdata->offset[0] = card_offset;
+		gfxdata->offset[0] = zbm->card_offset;
 		gfxdata->u8_user[0] = 0;
 		zzwrite16(&registers->blitter_acc_op, ACC_OP_FREE_SURFACE);
 	}
 
-	FreeMem(bm, sizeof(struct BitMap));
+	FreeMem(zbm, sizeof(struct ZZBitMap));
 	return TRUE;
+}
+
+ULONG ZZ_GetBitMapAttr(__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGD0(ULONG attr)) {
+	struct ZZBitMapAttrs attrs;
+	struct ZZBitMap *zbm;
+
+	if (!bm) return 0;
+
+	if ((zbm = zz_bitmap_ours(b, bm))) {
+		attrs.memory = (uint32_t)bm->Planes[0];
+		attrs.basememory = (uint32_t)b->MemoryBase;
+		attrs.bytesperrow = bm->BytesPerRow;
+		attrs.bytesperpixel = zz_rgbformat_bytes_per_pixel(zbm->rgbformat);
+		attrs.bitsperpixel = zz_rgbformat_bits_per_pixel(zbm->rgbformat);
+		attrs.rgbformat = zbm->rgbformat;
+		attrs.width = zbm->width;
+		attrs.height = zbm->height;
+		attrs.depth = attrs.bitsperpixel;
+	} else {
+		/* foreign bitmap (system RAM, planar): answer from the plain
+		 * struct BitMap fields */
+		attrs.memory = (uint32_t)bm->Planes[0];
+		attrs.basememory = (uint32_t)b->MemoryBase;
+		attrs.bytesperrow = bm->BytesPerRow;
+		attrs.bytesperpixel = 1;
+		attrs.bitsperpixel = bm->Depth;
+		attrs.rgbformat = RGBFB_PLANAR;
+		attrs.width = (uint32_t)bm->BytesPerRow * 8;
+		attrs.height = bm->Rows;
+		attrs.depth = bm->Depth;
+	}
+
+	return zz_offscreen_attr(&attrs, attr);
 }
 
 // This function shall blit a planar bitmap anywhere in the 68K address space into a chunky bitmap in video RAM.

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -120,6 +120,8 @@ char dummies[128];
 #define ZZ_CARD_DATA_DISPLAY_ENABLED 4
 #define ZZ_CARD_DATA_SECONDARY_PALETTE 5
 #define ZZ_CARD_DATA_OFFSCREEN_BITMAPS 6
+/* first firmware whose surface allocator really frees (major<<8|minor) */
+#define OFFSCREEN_BITMAPS_MIN_FWREV 0x0204
 #define MNT_MANUFACTURER 0x6d6e
 #define ZZ9000_PRODUCT_Z2 0x3
 #define ZZ9000_PRODUCT_Z3 0x4
@@ -846,15 +848,20 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 	//b->ResetChip = (void *)NULL;
 	//b->GetFeatureAttrs = (void *)NULL;
 	/* Off-screen bitmaps in card VRAM (Z3 only; ZZ_AllocBitMap refuses
-	 * on Z2). Kill switch: ENV:ZZ9000-NO-OFFSCREEN, the ZZ9000.CFG
+	 * on Z2). Requires firmware 2.4+: its surface allocator actually
+	 * frees, while older firmware bump-allocates with a no-op free and
+	 * would leak VRAM on every bitmap free. Kill switch on capable
+	 * firmware: ENV:ZZ9000-NO-OFFSCREEN, the ZZ9000.CFG
 	 * offscreen_bitmaps key (both read in FindCard), or the
 	 * OFFSCREENBITMAPS tooltype, which wins over both. */
 	{
+		UWORD fwrev = ((volatile uint16_t*)b->RegisterBase)[0xC0/2];
 		BOOL offscreen = (BOOL)b->CardData[ZZ_CARD_DATA_OFFSCREEN_BITMAPS];
 		const char *value = tooltype_value(tool_types, "OFFSCREENBITMAPS");
 		if (value)
 			offscreen = !value_is_false(value);
-		if (offscreen && (b->CardFlags & CARDFLAG_ZORRO_3)) {
+		if (offscreen && fwrev >= OFFSCREEN_BITMAPS_MIN_FWREV &&
+				(b->CardFlags & CARDFLAG_ZORRO_3)) {
 			b->AllocBitMap = (void *)ZZ_AllocBitMap;
 			b->FreeBitMap = (void *)ZZ_FreeBitMap;
 			b->GetBitMapAttr = (void *)ZZ_GetBitMapAttr;

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -1877,9 +1877,11 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 			case ABMA_ConstantBytesPerRow: bytesperrow_override = tag->ti_Data; break;
 			case ABMA_Alignment: alignment = tag->ti_Data; break;
 			/* requests we cannot honor in card VRAM: CPU-owned
-			 * fast-mem bitmaps, caller-supplied memory, byte-swapped
-			 * views -> NULL so P96 uses system RAM */
+			 * fast-mem bitmaps, explicit system-memory bitmaps,
+			 * caller-supplied memory, byte-swapped views -> NULL so
+			 * P96 uses system RAM */
 			case ABMA_UserPrivate:
+			case ABMA_System:
 			case ABMA_Memory:
 			case ABMA_ConstantByteSwapping:
 				if (tag->ti_Data) return NULL;

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -1863,8 +1863,9 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 
 	MNTZZ9KRegs* registers = (MNTZZ9KRegs*)b->RegisterBase;
 	ULONG rgbformat = RGBFB_CLUT;
-	ULONG bytesperrow_override = 0;
+	ULONG mode_width = 0;
 	ULONG alignment = 0;
+	BOOL constant_pitch = FALSE;
 
 	struct TagItem *tag = tags;
 	while (tag && tag->ti_Tag != TAG_DONE) {
@@ -1874,7 +1875,10 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 			case TAG_MORE: tag = (struct TagItem *)tag->ti_Data; continue;
 			case ABMA_RGBFormat: rgbformat = tag->ti_Data; break;
 			case ABMA_NoMemory: return NULL;
-			case ABMA_ConstantBytesPerRow: bytesperrow_override = tag->ti_Data; break;
+			/* a flag, not a pitch: the stride must not depend on the
+			 * bitmap width (ABMA_ModeWidth carries the mode's width) */
+			case ABMA_ConstantBytesPerRow: constant_pitch = tag->ti_Data != 0; break;
+			case ABMA_ModeWidth: mode_width = tag->ti_Data; break;
 			case ABMA_Alignment: alignment = tag->ti_Data; break;
 			/* requests we cannot honor in card VRAM: CPU-owned
 			 * fast-mem bitmaps, explicit system-memory bitmaps,
@@ -1903,19 +1907,16 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 	uint32_t pitch_align = (alignment > ZZ_OFFSCREEN_PITCH_ALIGN) ?
 		alignment : ZZ_OFFSCREEN_PITCH_ALIGN;
 
-	uint16_t bytesperrow;
-	if (bytesperrow_override) {
-		/* P96 demands this exact stride; refuse what the blitter
-		 * cannot step (pitches are programmed as BytesPerRow >> 2)
-		 * or what breaks the requested row alignment */
-		if (bytesperrow_override & (pitch_align - 1))
-			return NULL;
-		bytesperrow = bytesperrow_override;
-	} else {
-		bytesperrow = zz_offscreen_pad_pitch_to(
-			CalculateBytesPerRow(b, NULL, width, height, rgbformat),
-			pitch_align);
-	}
+	/* constant pitch: derive the stride from the display mode's width
+	 * so every bitmap of that mode/format shares it; the padding is
+	 * deterministic, which keeps it constant */
+	ULONG pitch_width = width;
+	if (constant_pitch && mode_width > pitch_width)
+		pitch_width = mode_width;
+
+	uint16_t bytesperrow = zz_offscreen_pad_pitch_to(
+		CalculateBytesPerRow(b, NULL, pitch_width, height, rgbformat),
+		pitch_align);
 	uint32_t size = (uint32_t)bytesperrow * height;
 	if (!size) return NULL;
 

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -1821,21 +1821,36 @@ void DrawLine(__REGA0(struct BoardInfo *b), __REGA1(struct RenderInfo *r), __REG
 }
 
 /* Off-screen bitmaps we place in card VRAM. `bm` must stay the first
- * member so the struct BitMap* P96 hands back is also a ZZBitMap*;
- * magic + the Planes[0] range check tell ours apart from foreign
- * (system RAM / planar) bitmaps. */
+ * member so the struct BitMap* P96 hands back is also a ZZBitMap*.
+ * All live wrappers sit on zz_bitmap_list; the pointer-identity walk
+ * decides ours/foreign, with magic + the Planes[0] range check kept as
+ * consistency guards. */
 struct ZZBitMap {
 	struct BitMap bm;
+	struct ZZBitMap *next;
 	ULONG magic;
 	ULONG card_offset;
 	ULONG rgbformat;
 	UWORD width, height;
 };
 
-static struct ZZBitMap *zz_bitmap_ours(struct BoardInfo *b, struct BitMap *bm) {
-	struct ZZBitMap *zbm = (struct ZZBitMap *)bm;
+static struct ZZBitMap *zz_bitmap_list = NULL;
 
-	if (!bm || !zz_offscreen_is_ours(zbm->magic, (uint32_t)bm->Planes[0],
+static struct ZZBitMap *zz_bitmap_ours(struct BoardInfo *b, struct BitMap *bm) {
+	struct ZZBitMap *zbm;
+
+	if (!bm)
+		return NULL;
+
+	/* membership first: never read wrapper fields (they sit past the
+	 * end of a plain struct BitMap) before proving bm is ours */
+	for (zbm = zz_bitmap_list; zbm; zbm = zbm->next)
+		if (&zbm->bm == bm)
+			break;
+	if (!zbm)
+		return NULL;
+
+	if (!zz_offscreen_is_ours(zbm->magic, (uint32_t)bm->Planes[0],
 			(uint32_t)b->MemoryBase, (uint32_t)b->MemorySize))
 		return NULL;
 
@@ -1849,6 +1864,7 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 	MNTZZ9KRegs* registers = (MNTZZ9KRegs*)b->RegisterBase;
 	ULONG rgbformat = RGBFB_CLUT;
 	ULONG bytesperrow_override = 0;
+	ULONG alignment = 0;
 
 	struct TagItem *tag = tags;
 	while (tag && tag->ti_Tag != TAG_DONE) {
@@ -1859,6 +1875,7 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 			case ABMA_RGBFormat: rgbformat = tag->ti_Data; break;
 			case ABMA_NoMemory: return NULL;
 			case ABMA_ConstantBytesPerRow: bytesperrow_override = tag->ti_Data; break;
+			case ABMA_Alignment: alignment = tag->ti_Data; break;
 			/* requests we cannot honor in card VRAM: CPU-owned
 			 * fast-mem bitmaps, caller-supplied memory, byte-swapped
 			 * views -> NULL so P96 uses system RAM */
@@ -1877,16 +1894,25 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 	if (!zz_rgbformat_bytes_per_pixel(rgbformat))
 		return NULL;
 
+	/* the firmware allocator starts surfaces 256-byte aligned; refuse
+	 * alignment requests we cannot promise */
+	if (alignment && !zz_offscreen_align_valid(alignment))
+		return NULL;
+	uint32_t pitch_align = (alignment > ZZ_OFFSCREEN_PITCH_ALIGN) ?
+		alignment : ZZ_OFFSCREEN_PITCH_ALIGN;
+
 	uint16_t bytesperrow;
 	if (bytesperrow_override) {
 		/* P96 demands this exact stride; refuse what the blitter
-		 * cannot step (pitches are programmed as BytesPerRow >> 2) */
-		if (bytesperrow_override & (ZZ_OFFSCREEN_PITCH_ALIGN - 1))
+		 * cannot step (pitches are programmed as BytesPerRow >> 2)
+		 * or what breaks the requested row alignment */
+		if (bytesperrow_override & (pitch_align - 1))
 			return NULL;
 		bytesperrow = bytesperrow_override;
 	} else {
-		bytesperrow = zz_offscreen_pad_pitch(
-			CalculateBytesPerRow(b, NULL, width, height, rgbformat));
+		bytesperrow = zz_offscreen_pad_pitch_to(
+			CalculateBytesPerRow(b, NULL, width, height, rgbformat),
+			pitch_align);
 	}
 	uint32_t size = (uint32_t)bytesperrow * height;
 	if (!size) return NULL;
@@ -1916,6 +1942,8 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 	zbm->rgbformat = rgbformat;
 	zbm->width = width;
 	zbm->height = height;
+	zbm->next = zz_bitmap_list;
+	zz_bitmap_list = zbm;
 
 	return &zbm->bm;
 }
@@ -1923,6 +1951,12 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 BOOL ZZ_FreeBitMap(__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGA2(struct TagItem *tags)) {
 	struct ZZBitMap *zbm = zz_bitmap_ours(b, bm);
 	if (!zbm) return FALSE;
+
+	struct ZZBitMap **pp = &zz_bitmap_list;
+	while (*pp && *pp != zbm)
+		pp = &(*pp)->next;
+	if (*pp)
+		*pp = zbm->next;
 
 	if (b->CardFlags & CARDFLAG_ZORRO_3) {
 		MNTZZ9KRegs* registers = (MNTZZ9KRegs*)b->RegisterBase;

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -1859,6 +1859,14 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 			case ABMA_RGBFormat: rgbformat = tag->ti_Data; break;
 			case ABMA_NoMemory: return NULL;
 			case ABMA_ConstantBytesPerRow: bytesperrow_override = tag->ti_Data; break;
+			/* requests we cannot honor in card VRAM: CPU-owned
+			 * fast-mem bitmaps, caller-supplied memory, byte-swapped
+			 * views -> NULL so P96 uses system RAM */
+			case ABMA_UserPrivate:
+			case ABMA_Memory:
+			case ABMA_ConstantByteSwapping:
+				if (tag->ti_Data) return NULL;
+				break;
 			/* ABMA_Clear needs no handling: the firmware zero-fills
 			 * every surface it allocates */
 			default: break;
@@ -1901,7 +1909,7 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 
 	zbm->bm.BytesPerRow = bytesperrow;
 	zbm->bm.Rows = height;
-	zbm->bm.Depth = (UBYTE)zz_rgbformat_bits_per_pixel(rgbformat);
+	zbm->bm.Depth = (UBYTE)zz_rgbformat_depth(rgbformat);
 	zbm->bm.Planes[0] = (PLANEPTR)((uint32_t)b->MemoryBase + card_offset);
 	zbm->magic = ZZ_OFFSCREEN_MAGIC;
 	zbm->card_offset = card_offset;
@@ -1939,11 +1947,12 @@ ULONG ZZ_GetBitMapAttr(__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm),
 		attrs.basememory = (uint32_t)b->MemoryBase;
 		attrs.bytesperrow = bm->BytesPerRow;
 		attrs.bytesperpixel = zz_rgbformat_bytes_per_pixel(zbm->rgbformat);
-		attrs.bitsperpixel = zz_rgbformat_bits_per_pixel(zbm->rgbformat);
+		attrs.bitsperpixel = zz_rgbformat_storage_bits(zbm->rgbformat);
 		attrs.rgbformat = zbm->rgbformat;
 		attrs.width = zbm->width;
 		attrs.height = zbm->height;
-		attrs.depth = attrs.bitsperpixel;
+		/* ModeInfo convention: color depth, 15 for RGB555 */
+		attrs.depth = zz_rgbformat_depth(zbm->rgbformat);
 	} else {
 		/* foreign bitmap (system RAM, planar): answer from the plain
 		 * struct BitMap fields */

--- a/rtg/mntgfx-gcc.h
+++ b/rtg/mntgfx-gcc.h
@@ -79,6 +79,7 @@ void BlitPlanar2Direct (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bmp
 
 struct BitMap * ZZ_AllocBitMap (__REGA0(struct BoardInfo *b), __REGD0(ULONG width), __REGD1(ULONG height), __REGA1(struct TagItem *tags));
 BOOL ZZ_FreeBitMap (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGA2(struct TagItem *tags));
+ULONG ZZ_GetBitMapAttr (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGD0(ULONG attr));
 
 BOOL SetSprite (__REGA0(struct BoardInfo *b), __REGD0(BOOL what), __REGD7(RGBFTYPE format));
 void SetSpritePosition (__REGA0(struct BoardInfo *b), __REGD0(WORD x), __REGD1(WORD y), __REGD7(RGBFTYPE format));

--- a/rtg/offscreen_bitmap.h
+++ b/rtg/offscreen_bitmap.h
@@ -14,6 +14,16 @@
 
 #define ZZ_OFFSCREEN_MAGIC 0x5A5A424Du /* 'ZZBM' */
 
+/* The blitter programs pitches in longword units (BytesPerRow >> 2),
+ * so off-screen strides must be multiples of 4 bytes. */
+#define ZZ_OFFSCREEN_PITCH_ALIGN 4u
+
+static inline uint32_t zz_offscreen_pad_pitch(uint32_t bytesperrow)
+{
+	return (bytesperrow + (ZZ_OFFSCREEN_PITCH_ALIGN - 1)) &
+		~(ZZ_OFFSCREEN_PITCH_ALIGN - 1);
+}
+
 /* GBMA_* GetBitMapAttr tags (mirror boardinfo.h: TAG_USER + n). */
 #define ZZ_GBMA_MEMORY        0x80000000u
 #define ZZ_GBMA_BASEMEMORY    0x80000001u

--- a/rtg/offscreen_bitmap.h
+++ b/rtg/offscreen_bitmap.h
@@ -18,10 +18,31 @@
  * so off-screen strides must be multiples of 4 bytes. */
 #define ZZ_OFFSCREEN_PITCH_ALIGN 4u
 
+/* The firmware allocator hands out 256-byte-aligned surfaces, so that
+ * is the strongest row alignment (ABMA_Alignment) we can promise. */
+#define ZZ_OFFSCREEN_MAX_ALIGN 256u
+
+/* An ABMA_Alignment request we can honor: a power of two no stronger
+ * than the allocator's start-address guarantee. */
+static inline int zz_offscreen_align_valid(uint32_t align)
+{
+	return align != 0 && (align & (align - 1)) == 0 &&
+		align <= ZZ_OFFSCREEN_MAX_ALIGN;
+}
+
+/* Pad a stride so every row keeps `align` alignment (rows stay aligned
+ * when the pitch is a multiple of it); the blitter minimum applies. */
+static inline uint32_t zz_offscreen_pad_pitch_to(uint32_t bytesperrow,
+	uint32_t align)
+{
+	if (align < ZZ_OFFSCREEN_PITCH_ALIGN)
+		align = ZZ_OFFSCREEN_PITCH_ALIGN;
+	return (bytesperrow + align - 1) & ~(align - 1);
+}
+
 static inline uint32_t zz_offscreen_pad_pitch(uint32_t bytesperrow)
 {
-	return (bytesperrow + (ZZ_OFFSCREEN_PITCH_ALIGN - 1)) &
-		~(ZZ_OFFSCREEN_PITCH_ALIGN - 1);
+	return zz_offscreen_pad_pitch_to(bytesperrow, ZZ_OFFSCREEN_PITCH_ALIGN);
 }
 
 /* GBMA_* GetBitMapAttr tags (mirror boardinfo.h: TAG_USER + n). */

--- a/rtg/offscreen_bitmap.h
+++ b/rtg/offscreen_bitmap.h
@@ -50,7 +50,10 @@ static inline uint32_t zz_rgbformat_bytes_per_pixel(uint32_t rgbformat)
 	return 0;
 }
 
-static inline uint32_t zz_rgbformat_bits_per_pixel(uint32_t rgbformat)
+/* Format color depth, the P96 ModeInfo convention: RGB555 is a
+ * "15-bit" format even though it occupies 16 bits of storage. Feeds
+ * struct BitMap Depth and GBMA_DEPTH. */
+static inline uint32_t zz_rgbformat_depth(uint32_t rgbformat)
 {
 	switch (rgbformat) {
 		case 1:  return 8;
@@ -60,6 +63,12 @@ static inline uint32_t zz_rgbformat_bits_per_pixel(uint32_t rgbformat)
 	}
 
 	return 0;
+}
+
+/* Storage bits per pixel (GBMA_BITSPERPIXEL): 16 for RGB555. */
+static inline uint32_t zz_rgbformat_storage_bits(uint32_t rgbformat)
+{
+	return zz_rgbformat_bytes_per_pixel(rgbformat) * 8;
 }
 
 /* Does (magic, pixels) identify a bitmap we allocated in card VRAM?

--- a/rtg/offscreen_bitmap.h
+++ b/rtg/offscreen_bitmap.h
@@ -1,0 +1,97 @@
+/*
+ * Pure helpers for P96 off-screen bitmaps placed in ZZ9000 card VRAM
+ * (the AllocBitMap/FreeBitMap/GetBitMapAttr hooks).
+ *
+ * No Amiga headers so the logic is host-testable; the driver keeps its
+ * metadata struct (which embeds struct BitMap) in mntgfx-gcc.c and
+ * passes plain integers in here.
+ */
+
+#ifndef ZZ9000_OFFSCREEN_BITMAP_H
+#define ZZ9000_OFFSCREEN_BITMAP_H
+
+#include <stdint.h>
+
+#define ZZ_OFFSCREEN_MAGIC 0x5A5A424Du /* 'ZZBM' */
+
+/* GBMA_* GetBitMapAttr tags (mirror boardinfo.h: TAG_USER + n). */
+#define ZZ_GBMA_MEMORY        0x80000000u
+#define ZZ_GBMA_BASEMEMORY    0x80000001u
+#define ZZ_GBMA_BYTESPERROW   0x80000002u
+#define ZZ_GBMA_BYTESPERPIXEL 0x80000003u
+#define ZZ_GBMA_BITSPERPIXEL  0x80000004u
+#define ZZ_GBMA_RGBFORMAT     0x80000006u
+#define ZZ_GBMA_WIDTH         0x80000007u
+#define ZZ_GBMA_HEIGHT        0x80000008u
+#define ZZ_GBMA_DEPTH         0x80000009u
+
+/* Bytes per pixel for the RGBFB formats the card advertises
+ * (ZZ_SUPPORTED_RGB_FORMATS); 0 for planar and everything else, which
+ * makes AllocBitMap refuse and P96 fall back to system RAM. */
+static inline uint32_t zz_rgbformat_bytes_per_pixel(uint32_t rgbformat)
+{
+	switch (rgbformat) {
+		case 1:  return 1; /* RGBFB_CLUT */
+		case 9:  return 4; /* RGBFB_B8G8R8A8 */
+		case 10: return 2; /* RGBFB_R5G6B5 */
+		case 11: return 2; /* RGBFB_R5G5B5 */
+	}
+
+	return 0;
+}
+
+static inline uint32_t zz_rgbformat_bits_per_pixel(uint32_t rgbformat)
+{
+	switch (rgbformat) {
+		case 1:  return 8;
+		case 9:  return 32;
+		case 10: return 16;
+		case 11: return 15;
+	}
+
+	return 0;
+}
+
+/* Does (magic, pixels) identify a bitmap we allocated in card VRAM?
+ * The range check guards against a stale/forged magic: our pixel data
+ * always lives inside the board memory window. */
+static inline int zz_offscreen_is_ours(uint32_t magic, uint32_t pixels,
+	uint32_t membase, uint32_t memsize)
+{
+	return magic == ZZ_OFFSCREEN_MAGIC &&
+		pixels >= membase && pixels - membase < memsize;
+}
+
+/* Everything GetBitMapAttr can be asked about, pre-resolved by the
+ * caller either from our metadata or from plain planar BitMap fields. */
+struct ZZBitMapAttrs {
+	uint32_t memory;        /* pixel data address (Planes[0]) */
+	uint32_t basememory;    /* board MemoryBase */
+	uint32_t bytesperrow;
+	uint32_t bytesperpixel;
+	uint32_t bitsperpixel;
+	uint32_t rgbformat;
+	uint32_t width;
+	uint32_t height;
+	uint32_t depth;
+};
+
+static inline uint32_t zz_offscreen_attr(const struct ZZBitMapAttrs *attrs,
+	uint32_t attr)
+{
+	switch (attr) {
+		case ZZ_GBMA_MEMORY:        return attrs->memory;
+		case ZZ_GBMA_BASEMEMORY:    return attrs->basememory;
+		case ZZ_GBMA_BYTESPERROW:   return attrs->bytesperrow;
+		case ZZ_GBMA_BYTESPERPIXEL: return attrs->bytesperpixel;
+		case ZZ_GBMA_BITSPERPIXEL:  return attrs->bitsperpixel;
+		case ZZ_GBMA_RGBFORMAT:     return attrs->rgbformat;
+		case ZZ_GBMA_WIDTH:         return attrs->width;
+		case ZZ_GBMA_HEIGHT:        return attrs->height;
+		case ZZ_GBMA_DEPTH:         return attrs->depth;
+	}
+
+	return 0;
+}
+
+#endif

--- a/rtg/tests/Makefile
+++ b/rtg/tests/Makefile
@@ -2,13 +2,14 @@ CC ?= cc
 CFLAGS ?= -O2 -g
 
 TARGET := build/register_cache_test
-TARGETS := $(TARGET) build/p96_settings_test
+TARGETS := $(TARGET) build/p96_settings_test build/offscreen_bitmap_test
 
 .PHONY: test clean
 
 test: $(TARGETS)
 	$(TARGET)
 	build/p96_settings_test
+	build/offscreen_bitmap_test
 
 $(TARGET): register_cache_test.c ../blitter_cache.h
 	@mkdir -p build
@@ -17,6 +18,10 @@ $(TARGET): register_cache_test.c ../blitter_cache.h
 build/p96_settings_test: p96_settings_test.c
 	@mkdir -p build
 	$(CC) -Wall -Wextra $(CFLAGS) -o $@ p96_settings_test.c
+
+build/offscreen_bitmap_test: offscreen_bitmap_test.c ../offscreen_bitmap.h
+	@mkdir -p build
+	$(CC) -Wall -Wextra $(CFLAGS) -I.. -o $@ offscreen_bitmap_test.c
 
 clean:
 	rm -rf build

--- a/rtg/tests/offscreen_bitmap_test.c
+++ b/rtg/tests/offscreen_bitmap_test.c
@@ -59,6 +59,30 @@ static void test_pad_pitch(void)
 	CHECK(zz_offscreen_pad_pitch(5120) == 5120);
 }
 
+static void test_alignment(void)
+{
+	/* honorable ABMA_Alignment values: powers of two up to the
+	 * allocator's 256-byte start-address guarantee */
+	CHECK(zz_offscreen_align_valid(1));
+	CHECK(zz_offscreen_align_valid(4));
+	CHECK(zz_offscreen_align_valid(16));
+	CHECK(zz_offscreen_align_valid(64));
+	CHECK(zz_offscreen_align_valid(256));
+	CHECK(!zz_offscreen_align_valid(0));
+	CHECK(!zz_offscreen_align_valid(3));
+	CHECK(!zz_offscreen_align_valid(24));
+	CHECK(!zz_offscreen_align_valid(512));
+	CHECK(!zz_offscreen_align_valid(0x80000000u));
+
+	/* pitch padding to a requested row alignment; blitter minimum of
+	 * 4 always applies */
+	CHECK(zz_offscreen_pad_pitch_to(17, 0) == 20);
+	CHECK(zz_offscreen_pad_pitch_to(17, 16) == 32);
+	CHECK(zz_offscreen_pad_pitch_to(100, 64) == 128);
+	CHECK(zz_offscreen_pad_pitch_to(256, 256) == 256);
+	CHECK(zz_offscreen_pad_pitch_to(257, 256) == 512);
+}
+
 static void test_is_ours(void)
 {
 	const uint32_t base = 0x40000000u, size = 0x04000000u; /* 64 MB Z3 */
@@ -150,6 +174,7 @@ int main(void)
 {
 	test_format_tables();
 	test_pad_pitch();
+	test_alignment();
 	test_is_ours();
 	test_attr_dispatch();
 	test_planar_fallback_shape();

--- a/rtg/tests/offscreen_bitmap_test.c
+++ b/rtg/tests/offscreen_bitmap_test.c
@@ -26,10 +26,14 @@ static void test_format_tables(void)
 	CHECK(zz_rgbformat_bytes_per_pixel(9) == 4);   /* B8G8R8A8 */
 	CHECK(zz_rgbformat_bytes_per_pixel(10) == 2);  /* R5G6B5 */
 	CHECK(zz_rgbformat_bytes_per_pixel(11) == 2);  /* R5G5B5 */
-	CHECK(zz_rgbformat_bits_per_pixel(1) == 8);
-	CHECK(zz_rgbformat_bits_per_pixel(9) == 32);
-	CHECK(zz_rgbformat_bits_per_pixel(10) == 16);
-	CHECK(zz_rgbformat_bits_per_pixel(11) == 15);
+	CHECK(zz_rgbformat_depth(1) == 8);
+	CHECK(zz_rgbformat_depth(9) == 32);
+	CHECK(zz_rgbformat_depth(10) == 16);
+	CHECK(zz_rgbformat_depth(11) == 15);   /* color depth: "15-bit" mode */
+	CHECK(zz_rgbformat_storage_bits(1) == 8);
+	CHECK(zz_rgbformat_storage_bits(9) == 32);
+	CHECK(zz_rgbformat_storage_bits(10) == 16);
+	CHECK(zz_rgbformat_storage_bits(11) == 16); /* but 16 bits of storage */
 
 	/* planar, unsupported orders, YUV, out of range: all refused */
 	CHECK(zz_rgbformat_bytes_per_pixel(0) == 0);   /* RGBFB_NONE/planar */
@@ -38,8 +42,9 @@ static void test_format_tables(void)
 	CHECK(zz_rgbformat_bytes_per_pixel(14) == 0);  /* YUV 4:2:2 */
 	CHECK(zz_rgbformat_bytes_per_pixel(21) == 0);
 	CHECK(zz_rgbformat_bytes_per_pixel(0xffffffffu) == 0);
-	CHECK(zz_rgbformat_bits_per_pixel(0) == 0);
-	CHECK(zz_rgbformat_bits_per_pixel(6) == 0);
+	CHECK(zz_rgbformat_depth(0) == 0);
+	CHECK(zz_rgbformat_depth(6) == 0);
+	CHECK(zz_rgbformat_storage_bits(0) == 0);
 }
 
 static void test_pad_pitch(void)
@@ -101,6 +106,22 @@ static void test_attr_dispatch(void)
 	CHECK(zz_offscreen_attr(&a, 0x8000000Au) == 0);
 	CHECK(zz_offscreen_attr(&a, 0) == 0);
 	CHECK(zz_offscreen_attr(&a, 1) == 0);
+
+	/* RGB555: 15-bit color depth in 16 bits of storage */
+	struct ZZBitMapAttrs a15 = {
+		.memory = 0x40200000u,
+		.basememory = 0x40000000u,
+		.bytesperrow = 640 * 2,
+		.bytesperpixel = 2,
+		.bitsperpixel = zz_rgbformat_storage_bits(11),
+		.rgbformat = 11,
+		.width = 640,
+		.height = 480,
+		.depth = zz_rgbformat_depth(11),
+	};
+	CHECK(zz_offscreen_attr(&a15, ZZ_GBMA_DEPTH) == 15);
+	CHECK(zz_offscreen_attr(&a15, ZZ_GBMA_BITSPERPIXEL) == 16);
+	CHECK(zz_offscreen_attr(&a15, ZZ_GBMA_BYTESPERPIXEL) == 2);
 }
 
 static void test_planar_fallback_shape(void)

--- a/rtg/tests/offscreen_bitmap_test.c
+++ b/rtg/tests/offscreen_bitmap_test.c
@@ -1,0 +1,130 @@
+/*
+ * Host tests for the off-screen bitmap helpers (offscreen_bitmap.h).
+ *
+ * Build/run: make -C rtg/tests test (or `make rtg-tests` from the root).
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include "offscreen_bitmap.h"
+
+static int failures = 0;
+static int checks = 0;
+
+#define CHECK(cond) do { \
+	checks++; \
+	if (!(cond)) { \
+		failures++; \
+		printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+	} \
+} while (0)
+
+static void test_format_tables(void)
+{
+	/* the four chunky formats the card advertises */
+	CHECK(zz_rgbformat_bytes_per_pixel(1) == 1);   /* CLUT */
+	CHECK(zz_rgbformat_bytes_per_pixel(9) == 4);   /* B8G8R8A8 */
+	CHECK(zz_rgbformat_bytes_per_pixel(10) == 2);  /* R5G6B5 */
+	CHECK(zz_rgbformat_bytes_per_pixel(11) == 2);  /* R5G5B5 */
+	CHECK(zz_rgbformat_bits_per_pixel(1) == 8);
+	CHECK(zz_rgbformat_bits_per_pixel(9) == 32);
+	CHECK(zz_rgbformat_bits_per_pixel(10) == 16);
+	CHECK(zz_rgbformat_bits_per_pixel(11) == 15);
+
+	/* planar, unsupported orders, YUV, out of range: all refused */
+	CHECK(zz_rgbformat_bytes_per_pixel(0) == 0);   /* RGBFB_NONE/planar */
+	CHECK(zz_rgbformat_bytes_per_pixel(2) == 0);   /* 24BPP RGB */
+	CHECK(zz_rgbformat_bytes_per_pixel(6) == 0);   /* 32BPP ARGB */
+	CHECK(zz_rgbformat_bytes_per_pixel(14) == 0);  /* YUV 4:2:2 */
+	CHECK(zz_rgbformat_bytes_per_pixel(21) == 0);
+	CHECK(zz_rgbformat_bytes_per_pixel(0xffffffffu) == 0);
+	CHECK(zz_rgbformat_bits_per_pixel(0) == 0);
+	CHECK(zz_rgbformat_bits_per_pixel(6) == 0);
+}
+
+static void test_is_ours(void)
+{
+	const uint32_t base = 0x40000000u, size = 0x04000000u; /* 64 MB Z3 */
+
+	CHECK(zz_offscreen_is_ours(ZZ_OFFSCREEN_MAGIC, base, base, size));
+	CHECK(zz_offscreen_is_ours(ZZ_OFFSCREEN_MAGIC, base + size - 4, base, size));
+
+	/* wrong magic */
+	CHECK(!zz_offscreen_is_ours(0, base, base, size));
+	CHECK(!zz_offscreen_is_ours(0xDEADBEEFu, base, base, size));
+	/* pixels outside the board window (system-RAM bitmap) */
+	CHECK(!zz_offscreen_is_ours(ZZ_OFFSCREEN_MAGIC, base - 4, base, size));
+	CHECK(!zz_offscreen_is_ours(ZZ_OFFSCREEN_MAGIC, base + size, base, size));
+	CHECK(!zz_offscreen_is_ours(ZZ_OFFSCREEN_MAGIC, 0, base, size));
+	/* wrap-around does not sneak in */
+	CHECK(!zz_offscreen_is_ours(ZZ_OFFSCREEN_MAGIC, base - 1, base, 0xffffffffu - base + 1));
+}
+
+static void test_attr_dispatch(void)
+{
+	struct ZZBitMapAttrs a = {
+		.memory = 0x40100000u,
+		.basememory = 0x40000000u,
+		.bytesperrow = 1280 * 4,
+		.bytesperpixel = 4,
+		.bitsperpixel = 32,
+		.rgbformat = 9,
+		.width = 1280,
+		.height = 720,
+		.depth = 32,
+	};
+
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_MEMORY) == 0x40100000u);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_BASEMEMORY) == 0x40000000u);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_BYTESPERROW) == 5120);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_BYTESPERPIXEL) == 4);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_BITSPERPIXEL) == 32);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_RGBFORMAT) == 9);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_WIDTH) == 1280);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_HEIGHT) == 720);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_DEPTH) == 32);
+
+	/* unknown attrs read 0 (including the gap at TAG_USER+5) */
+	CHECK(zz_offscreen_attr(&a, 0x80000005u) == 0);
+	CHECK(zz_offscreen_attr(&a, 0x8000000Au) == 0);
+	CHECK(zz_offscreen_attr(&a, 0) == 0);
+	CHECK(zz_offscreen_attr(&a, 1) == 0);
+}
+
+static void test_planar_fallback_shape(void)
+{
+	/* a foreign planar bitmap resolved by the driver's fallback path:
+	 * BytesPerRow=80 (640px), Rows=256, Depth=3 */
+	struct ZZBitMapAttrs a = {
+		.memory = 0x00200000u,   /* chip RAM plane */
+		.basememory = 0x40000000u,
+		.bytesperrow = 80,
+		.bytesperpixel = 1,
+		.bitsperpixel = 3,
+		.rgbformat = 0,          /* RGBFB_PLANAR */
+		.width = 80 * 8,
+		.height = 256,
+		.depth = 3,
+	};
+
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_WIDTH) == 640);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_DEPTH) == 3);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_RGBFORMAT) == 0);
+	CHECK(zz_offscreen_attr(&a, ZZ_GBMA_MEMORY) == 0x00200000u);
+}
+
+int main(void)
+{
+	test_format_tables();
+	test_is_ours();
+	test_attr_dispatch();
+	test_planar_fallback_shape();
+
+	if (failures) {
+		printf("%d of %d checks failed\n", failures, checks);
+		return 1;
+	}
+
+	printf("all %d offscreen bitmap checks passed\n", checks);
+	return 0;
+}

--- a/rtg/tests/offscreen_bitmap_test.c
+++ b/rtg/tests/offscreen_bitmap_test.c
@@ -42,6 +42,18 @@ static void test_format_tables(void)
 	CHECK(zz_rgbformat_bits_per_pixel(6) == 0);
 }
 
+static void test_pad_pitch(void)
+{
+	/* the blitter steps pitches in longwords: strides pad up to 4 */
+	CHECK(zz_offscreen_pad_pitch(0) == 0);
+	CHECK(zz_offscreen_pad_pitch(1) == 4);
+	CHECK(zz_offscreen_pad_pitch(3) == 4);
+	CHECK(zz_offscreen_pad_pitch(4) == 4);
+	CHECK(zz_offscreen_pad_pitch(17) == 20);   /* 17px CLUT bitmap */
+	CHECK(zz_offscreen_pad_pitch(34) == 36);   /* 17px hi/truecolor */
+	CHECK(zz_offscreen_pad_pitch(5120) == 5120);
+}
+
 static void test_is_ours(void)
 {
 	const uint32_t base = 0x40000000u, size = 0x04000000u; /* 64 MB Z3 */
@@ -116,6 +128,7 @@ static void test_planar_fallback_shape(void)
 int main(void)
 {
 	test_format_tables();
+	test_pad_pitch();
 	test_is_ours();
 	test_attr_dispatch();
 	test_planar_fallback_shape();


### PR DESCRIPTION
## What

Turns on the long-disabled `AllocBitMap`/`FreeBitMap` hooks so P96 places off-screen bitmaps (window backing store, icon/menu caches, double buffers) in card VRAM — off-screen↔screen blits then run on the card's blitter instead of the CPU copying over Zorro. Requires the firmware allocator from BlitterStudio/zz9000-firmware#50 (the old firmware bump allocator never freed, which is why these hooks were disabled).

## Changes

- **`ZZ_AllocBitMap`** allocates a `ZZBitMap` wrapper (`struct BitMap` first member, then magic + card offset + format metadata) and refuses formats the card cannot blit natively — P96 falls back to system RAM on any refusal, including Zorro 2 and VRAM exhaustion.
- **`ZZ_FreeBitMap`** and the new **`ZZ_GetBitMapAttr`** identify our bitmaps by magic plus a Planes[0]-in-board-window range check; foreign (system-RAM/planar) bitmaps are answered from their plain `BitMap` fields and never freed by us.
- `Depth` is now the format's bits per pixel instead of the hardcoded 1. If P96 misbehaves on hardware, reverting Depth to 1 is the first knob.
- **Kill switch, default ON**: `ENV:ZZ9000-NO-OFFSCREEN`, ZZ9000.CFG `offscreen_bitmaps = off` (firmware 2.3+), or the `OFFSCREENBITMAPS` icon tooltype (tooltype wins). When off, the hooks stay NULL — exactly today's behavior.
- Pure logic lives in `rtg/offscreen_bitmap.h`; host suite `rtg/tests/offscreen_bitmap_test.c` (41 checks) covers the format tables, ours/foreign classification, and `GetBitMapAttr` dispatch. `make rtg-tests` green, `ZZ9000.card` builds clean.

## Version skew

- Old firmware + this driver: allocs bump-allocate and frees leak (today's behavior) until exhaustion, where P96 falls back to system RAM. No corruption.
- New firmware + old driver: hooks absent, allocator idle. No corruption.

## Merge order / testing

Merge firmware #50 first and flash its CI BOOT.bin (no bitstream change), then this ZZ9000.card. Hardware checklist in the firmware PR.