### PR TITLE
WriteYUVRect: contract probe, then card-side YUV acceleration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,19 @@ jobs:
           name: ZZ9000.card
           path: rtg/ZZ9000.card
           if-no-files-found: error
+      - name: Build ZZ9000.card (debug/probe, KPrintF via Sashimi)
+        run: |
+          docker run --rm -v "$PWD":/src -w /src/rtg "$AMIGA_IMAGE" \
+            m68k-amigaos-gcc mntgfx-gcc.c -DDEBUG -m68020 -mtune=68020-60 -O2 \
+              -I../include \
+              -o ZZ9000-debug.card -noixemul -Wall -Wextra \
+              -Wno-unused-parameter -fomit-frame-pointer \
+              -nostartfiles -ldebug -lamiga
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ZZ9000-debug.card
+          path: rtg/ZZ9000-debug.card
+          if-no-files-found: error
 
   zztop:
     name: ZZTop

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -841,7 +841,9 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 	//b->AllocCardMemAbs = (void *)NULL;
 	b->SetSplitPosition = (void *)SetSplitPosition;
 	//b->ReInitMemory = (void *)NULL;
-	//b->WriteYUVRect = (void *)NULL;
+	/* Stage A contract probe: logs + delegates to WriteYUVRectDefault
+	 * (pure pass-through in release builds). See ZZ_WriteYUVRect. */
+	b->WriteYUVRect = (void *)ZZ_WriteYUVRect;
 	b->GetVSyncState = (void *)GetVSyncState;
 	//b->GetVBeamPos = (void *)NULL;
 	//b->SetDPMSLevel = (void *)NULL;
@@ -2005,6 +2007,69 @@ ULONG ZZ_GetBitMapAttr(__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm),
 	}
 
 	return zz_offscreen_attr(&attrs, attr);
+}
+
+/* WriteYUVRect contract probe (Stage A). P96 calls this hook from its
+ * software picture-in-picture path (p96PIP with a YUV source), but the
+ * TagItem contract - how the source stride and format arrive - is
+ * undocumented and P96's source is closed. This probe logs every
+ * argument, the full tag list and the head of the source data, then
+ * delegates to P96's own converter, so a Sashimi capture from a real
+ * PIP session defines the contract the accelerated implementation will
+ * code against. Build with -DDEBUG (and -ldebug) to enable the
+ * logging; a release build is a pure pass-through. */
+int ZZ_WriteYUVRect(__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHORT srcx), __REGD1(SHORT srcy), __REGA2(struct RenderInfo *r), __REGD2(SHORT dstx), __REGD3(SHORT dsty), __REGD4(SHORT w), __REGD5(SHORT h), __REGA3(struct TagItem *tags)) {
+	int result;
+#ifdef DEBUG
+	static ULONG yuv_calls = 0;
+	ULONG n = yuv_calls++;
+	int do_log = (n < 8) || ((n & 0xFF) == 0);
+
+	if (do_log) {
+		KPrintF("ZZ9000: WriteYUVRect #%ld src=%lx sx=%ld sy=%ld dst=%lx bpr=%ld fmt=%ld dx=%ld dy=%ld w=%ld h=%ld tags=%lx\n",
+			n, (ULONG)src, (LONG)srcx, (LONG)srcy,
+			(ULONG)(r ? (ULONG)r->Memory : 0),
+			(LONG)(r ? r->BytesPerRow : 0),
+			(LONG)(r ? (LONG)r->RGBFormat : -1),
+			(LONG)dstx, (LONG)dsty, (LONG)w, (LONG)h, (ULONG)tags);
+
+		struct TagItem *tag = tags;
+		int guard = 32;
+		while (tag && tag->ti_Tag != TAG_DONE && guard--) {
+			switch (tag->ti_Tag) {
+				case TAG_IGNORE: break;
+				case TAG_SKIP: tag += tag->ti_Data; break;
+				case TAG_MORE: tag = (struct TagItem *)tag->ti_Data; continue;
+				default:
+					KPrintF("ZZ9000:   tag=%08lx data=%08lx\n",
+						tag->ti_Tag, tag->ti_Data);
+					break;
+			}
+			tag++;
+		}
+
+		if (src) {
+			const UBYTE *p = (const UBYTE *)src;
+			KPrintF("ZZ9000:   src[0..7]=%02lx %02lx %02lx %02lx %02lx %02lx %02lx %02lx\n",
+				(ULONG)p[0], (ULONG)p[1], (ULONG)p[2], (ULONG)p[3],
+				(ULONG)p[4], (ULONG)p[5], (ULONG)p[6], (ULONG)p[7]);
+			KPrintF("ZZ9000:   src[8..15]=%02lx %02lx %02lx %02lx %02lx %02lx %02lx %02lx\n",
+				(ULONG)p[8], (ULONG)p[9], (ULONG)p[10], (ULONG)p[11],
+				(ULONG)p[12], (ULONG)p[13], (ULONG)p[14], (ULONG)p[15]);
+		}
+	}
+#endif
+
+	if (!b->WriteYUVRectDefault)
+		return 0;
+	result = b->WriteYUVRectDefault(b, src, srcx, srcy, r, dstx, dsty, w, h, tags);
+
+#ifdef DEBUG
+	if (do_log)
+		KPrintF("ZZ9000:   WriteYUVRectDefault returned %ld\n", (LONG)result);
+#endif
+
+	return result;
 }
 
 // This function shall blit a planar bitmap anywhere in the 68K address space into a chunky bitmap in video RAM.

--- a/rtg/mntgfx-gcc.h
+++ b/rtg/mntgfx-gcc.h
@@ -80,6 +80,7 @@ void BlitPlanar2Direct (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bmp
 struct BitMap * ZZ_AllocBitMap (__REGA0(struct BoardInfo *b), __REGD0(ULONG width), __REGD1(ULONG height), __REGA1(struct TagItem *tags));
 BOOL ZZ_FreeBitMap (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGA2(struct TagItem *tags));
 ULONG ZZ_GetBitMapAttr (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGD0(ULONG attr));
+int ZZ_WriteYUVRect (__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHORT srcx), __REGD1(SHORT srcy), __REGA2(struct RenderInfo *r), __REGD2(SHORT dstx), __REGD3(SHORT dsty), __REGD4(SHORT w), __REGD5(SHORT h), __REGA3(struct TagItem *tags));
 
 BOOL SetSprite (__REGA0(struct BoardInfo *b), __REGD0(BOOL what), __REGD7(RGBFTYPE format));
 void SetSpritePosition (__REGA0(struct BoardInfo *b), __REGD0(WORD x), __REGD1(WORD y), __REGD7(RGBFTYPE format));


### PR DESCRIPTION
## What (Stage A — this is a DRAFT until the probe data is in)

P96's software picture-in-picture path renders YUV PIP sources (video players via `p96PIP`) through the driver's `WriteYUVRect` hook — currently unimplemented, so P96's own 68060 converter does the work. The end goal is converting on the card via the new firmware `OP_WRITE_YUV` (BlitterStudio/zz9000-firmware#53).

**But the hook's TagItem contract — how the source stride and format arrive — is undocumented anywhere public**: P96's source is closed, AROS lists the hook as TODO, and no open driver implements it. So this lands in two stages on this branch:

1. **Stage A (this state): contract probe.** `WriteYUVRect` is installed and logs every argument, the full tag list, a hexdump of the source head and the Default's return value (rate-limited: first 8 calls, then every 256th), then delegates to `WriteYUVRectDefault`. Logging exists only in the `-DDEBUG -ldebug` build — CI now uploads that as the **`ZZ9000-debug.card`** artifact; the regular release build is a pure pass-through with zero rendering risk.
2. **Stage B (after the bench):** the captured Sashimi log defines the stride/tag conventions; the accelerated path (staging into the template scratch like BlitPlanar2Chunky, banding for large rects, firmware-2.5 gate, `ENV:ZZ9000-NO-YUV` / `YUVRECT` tooltype / ZZ9000.CFG `yuv_rect` kill switch, Default fallback for anything off-contract) is added here before merge.

## Bench instructions (Stage A)

- Flash the firmware PR's BOOT.bin (reports 2.5; not strictly needed for the probe but needed for Stage B).
- Use the **`ZZ9000-debug.card`** CI artifact as ZZ9000.card.
- Run Sashimi, open a p96PIP app playing YUV content (also worth confirming a YUV PIP opens at all — `PIPERR_BADDIMENSIONS` would mean P96 refuses the format before the hook is ever called).
- Paste the captured `ZZ9000: WriteYUVRect …` lines into this PR.

Key open questions the log answers: does P96 call the hook here at all; the tag IDs/values (stride?); whether the source pointer is pre-offset for srcx/srcy; which RGBFTYPEs appear; how P96's PIP scaling interacts with the hook's single w/h; the return-value convention.