### PR TITLE
P96 video window (PIP): Features API + BIF_VIDEOWINDOW

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,19 @@ jobs:
           name: ZZ9000.card
           path: rtg/ZZ9000.card
           if-no-files-found: error
+      - name: Build ZZ9000.card (debug/probe, KPrintF via Sashimi)
+        run: |
+          docker run --rm -v "$PWD":/src -w /src/rtg "$AMIGA_IMAGE" \
+            m68k-amigaos-gcc mntgfx-gcc.c -DDEBUG -m68020 -mtune=68020-60 -O2 \
+              -I../include \
+              -o ZZ9000-debug.card -noixemul -Wall -Wextra \
+              -Wno-unused-parameter -fomit-frame-pointer \
+              -nostartfiles -ldebug -lamiga
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ZZ9000-debug.card
+          path: rtg/ZZ9000-debug.card
+          if-no-files-found: error
 
   zztop:
     name: ZZTop

--- a/include/zzcfg_query.h
+++ b/include/zzcfg_query.h
@@ -32,6 +32,8 @@
 #define ZZ_CFG_KEY_MAC_MID         7
 #define ZZ_CFG_KEY_MAC_LO          8
 #define ZZ_CFG_KEY_OFFSCREEN_BITMAPS 9
+#define ZZ_CFG_KEY_YUV_RECT          10
+#define ZZ_CFG_KEY_VIDEO_OVERLAY     11
 
 /* ZZ_REG_CONFIG_FILE statuses (mirror firmware zz_config_file_status). */
 #define ZZ_CFG_FILE_OK           0

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -37,8 +37,6 @@
 #include "blitter_cache.h"
 #include "offscreen_bitmap.h"
 #include "overlay_feature.h"
-#include <clib/Picasso96_protos.h>
-#include <inline/Picasso96.h>
 
 #define STR(s) #s
 #define XSTR(s) STR(s)
@@ -906,10 +904,6 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 		if (pip && fwrev >= VIDEO_OVERLAY_MIN_FWREV &&
 				(b->CardFlags & CARDFLAG_ZORRO_3) && b->AllocBitMap) {
 			b->Flags |= BIF_VIDEOWINDOW;
-			/* required for ON-BOARD placement of the PIP source:
-			 * p96AllocBitMap only considers card VRAM for a
-			 * displayable bitmap whose format bit is advertised */
-			b->RGBFormats |= (UWORD)ZZ_OVERLAY_BOARD_FORMATS;
 			b->GetFeatureAttrs = (void *)ZZ_GetFeatureAttrs;
 			b->CreateFeature = (void *)ZZ_CreateFeature;
 			b->SetFeatureAttrs = (void *)ZZ_SetFeatureAttrs;
@@ -2131,7 +2125,6 @@ int ZZ_WriteYUVRect(__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHO
 
 static struct ZZOverlayState zz_overlay;
 static struct BitMap *zz_overlay_bitmap = NULL;
-static struct Library *P96Base = NULL;
 /* RastPort handed to the app for P96PIP_SourceRPort: wraps the source
  * bitmap; equivalent of InitRastPort defaults, built by hand so the
  * driver needs no graphics.library base */
@@ -2205,62 +2198,48 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		return NULL;
 	}
 
-	/* the source bitmap must be a P96-MANAGED bitmap: P96's cgxvideo
-	 * emulation (RiVA's PIP path) runs LockVLayer/GetVLayerAttr over
-	 * P96's own bitmap bookkeeping, which crashes on a bare
-	 * driver-allocated bitmap. p96AllocBitMap routes back through our
-	 * AllocBitMap hook for the on-board VRAM placement (exec
-	 * semaphores nest per task, so the re-entry is safe - WinUAE's
-	 * CreateFeature does the same call-back). */
-	if (!P96Base)
-		P96Base = OpenLibrary((APTR)"Picasso96API.library", 2);
-	if (!P96Base) {
-		KPrintF("ZZ9000: CreateFeature: no Picasso96API.library\n");
-		return NULL;
-	}
-
-	/* On-board placement needs BOARD AFFINITY: a friend bitmap that
-	 * lives in card VRAM (the same mechanism that routes off-screen
-	 * bitmaps through our AllocBitMap hook - friend-compatibility runs
-	 * through GetCompatibleFormats, where the YUV formats are OR'd in
-	 * while the hooks are enabled). BMF_DISPLAYABLE would do the
-	 * opposite: no display mode exists for YUV, so a displayable
-	 * request lands in system RAM. The PIP window sits on the default
-	 * public screen, whose bitmap is the natural friend. */
+	/* Allocate the YUV source through our own AllocBitMap hook with
+	 * the PicassoIV tag set (ABMA_Displayable/Visible/Clear - the tags
+	 * WinUAE's uaegfx CreateFeature copied from the PicassoIV driver,
+	 * which calls bi->AllocBitMap exactly like this). Board-pinned by
+	 * construction, so the source always lands in card VRAM. The
+	 * p96AllocBitMap detours were dead ends: without a friend it
+	 * places non-screen bitmaps in system RAM even with
+	 * BMF_DISPLAYABLE (no YUV display mode exists), and a
+	 * LockPubScreen friend deadlocks inside CreateFeature (P96 calls
+	 * us holding locks the pubscreen path contends on). The bare
+	 * bitmap is fine: rtg.library wraps feature bitmaps itself, the
+	 * same way every off-screen bitmap from this hook becomes
+	 * P96-managed. */
 	{
-		struct IntuitionBase *IntuitionBase =
-			(struct IntuitionBase *)OpenLibrary((APTR)"intuition.library", 36);
-		struct Screen *scr = NULL;
-		struct BitMap *friend_bm = NULL;
+		struct TagItem alloc_tags[5];
+		alloc_tags[0].ti_Tag = ABMA_RGBFormat;
+		alloc_tags[0].ti_Data = zz_overlay.rgbformat;
+		alloc_tags[1].ti_Tag = ABMA_Clear;
+		alloc_tags[1].ti_Data = 1;
+		alloc_tags[2].ti_Tag = ABMA_Displayable;
+		alloc_tags[2].ti_Data = 1;
+		alloc_tags[3].ti_Tag = ABMA_Visible;
+		alloc_tags[3].ti_Data = 1;
+		alloc_tags[4].ti_Tag = TAG_DONE;
+		alloc_tags[4].ti_Data = 0;
 
-		if (IntuitionBase) {
-			scr = LockPubScreen(NULL);
-			if (scr)
-				friend_bm = scr->RastPort.BitMap;
-		}
-
-		zz_overlay_bitmap = p96AllocBitMap(zz_overlay.src_w,
-			zz_overlay.src_h, 16, BMF_CLEAR, friend_bm,
-			(RGBFTYPE)zz_overlay.rgbformat);
-
-		if (scr)
-			UnlockPubScreen(NULL, scr);
-		if (IntuitionBase)
-			CloseLibrary((struct Library *)IntuitionBase);
+		zz_overlay_bitmap = ZZ_AllocBitMap(b, zz_overlay.src_w,
+			zz_overlay.src_h, alloc_tags);
 	}
 	if (!zz_overlay_bitmap) {
-		KPrintF("ZZ9000: CreateFeature p96AllocBitMap FAILED\n");
+		KPrintF("ZZ9000: CreateFeature AllocBitMap FAILED\n");
 		return NULL;
 	}
 
-	/* the compositor reads the source from card VRAM: refuse a bitmap
-	 * P96 placed in system RAM (fail the open cleanly) */
+	/* the compositor reads the source from card VRAM; ZZ_AllocBitMap
+	 * guarantees that, so this is a belt-and-braces diagnostic */
 	if ((uint32_t)zz_overlay_bitmap->Planes[0] < (uint32_t)b->MemoryBase ||
 	    (uint32_t)zz_overlay_bitmap->Planes[0] - (uint32_t)b->MemoryBase >=
 	    (uint32_t)b->MemorySize) {
 		KPrintF("ZZ9000: CreateFeature source NOT on board (%08lx)\n",
 			(ULONG)zz_overlay_bitmap->Planes[0]);
-		p96FreeBitMap(zz_overlay_bitmap);
+		ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
 		zz_overlay_bitmap = NULL;
 		return NULL;
 	}
@@ -2288,7 +2267,7 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 			KPrintF("ZZ9000: CreateFeature fw SET status %ld\n",
 				(LONG)fw_status);
 			zz_overlay.magic = 0;
-			p96FreeBitMap(zz_overlay_bitmap);
+			ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
 			zz_overlay_bitmap = NULL;
 			return NULL;
 		}
@@ -2409,7 +2388,7 @@ BOOL ZZ_DeleteFeature(__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0(UL
 
 	zz_overlay_push(b, 1);
 	zz_overlay.magic = 0;
-	p96FreeBitMap(zz_overlay_bitmap);
+	ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
 	zz_overlay_bitmap = NULL;
 
 	return TRUE;

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -37,6 +37,8 @@
 #include "blitter_cache.h"
 #include "offscreen_bitmap.h"
 #include "overlay_feature.h"
+#include <clib/Picasso96_protos.h>
+#include <inline/Picasso96.h>
 
 #define STR(s) #s
 #define XSTR(s) STR(s)
@@ -2125,6 +2127,7 @@ int ZZ_WriteYUVRect(__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHO
 
 static struct ZZOverlayState zz_overlay;
 static struct BitMap *zz_overlay_bitmap = NULL;
+static struct Library *P96Base = NULL;
 /* RastPort handed to the app for P96PIP_SourceRPort: wraps the source
  * bitmap; equivalent of InitRastPort defaults, built by hand so the
  * driver needs no graphics.library base */
@@ -2198,26 +2201,37 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		return NULL;
 	}
 
-	/* allocate the YUV source bitmap through our own AllocBitMap
-	 * (Displayable+Visible+Clear, the PicassoIV/WinUAE tag set) */
-	{
-		struct TagItem alloc_tags[5];
-		alloc_tags[0].ti_Tag = ABMA_RGBFormat;
-		alloc_tags[0].ti_Data = zz_overlay.rgbformat;
-		alloc_tags[1].ti_Tag = ABMA_Clear;
-		alloc_tags[1].ti_Data = 1;
-		alloc_tags[2].ti_Tag = ABMA_Displayable;
-		alloc_tags[2].ti_Data = 1;
-		alloc_tags[3].ti_Tag = ABMA_Visible;
-		alloc_tags[3].ti_Data = 1;
-		alloc_tags[4].ti_Tag = TAG_DONE;
-		alloc_tags[4].ti_Data = 0;
-
-		zz_overlay_bitmap = ZZ_AllocBitMap(b, zz_overlay.src_w,
-			zz_overlay.src_h, alloc_tags);
+	/* the source bitmap must be a P96-MANAGED bitmap: P96's cgxvideo
+	 * emulation (RiVA's PIP path) runs LockVLayer/GetVLayerAttr over
+	 * P96's own bitmap bookkeeping, which crashes on a bare
+	 * driver-allocated bitmap. p96AllocBitMap routes back through our
+	 * AllocBitMap hook for the on-board VRAM placement (exec
+	 * semaphores nest per task, so the re-entry is safe - WinUAE's
+	 * CreateFeature does the same call-back). */
+	if (!P96Base)
+		P96Base = OpenLibrary((APTR)"Picasso96API.library", 2);
+	if (!P96Base) {
+		KPrintF("ZZ9000: CreateFeature: no Picasso96API.library\n");
+		return NULL;
 	}
+
+	zz_overlay_bitmap = p96AllocBitMap(zz_overlay.src_w, zz_overlay.src_h,
+		16, BMF_CLEAR | BMF_DISPLAYABLE, NULL,
+		(RGBFTYPE)zz_overlay.rgbformat);
 	if (!zz_overlay_bitmap) {
-		KPrintF("ZZ9000: CreateFeature AllocBitMap FAILED\n");
+		KPrintF("ZZ9000: CreateFeature p96AllocBitMap FAILED\n");
+		return NULL;
+	}
+
+	/* the compositor reads the source from card VRAM: refuse a bitmap
+	 * P96 placed in system RAM (fail the open cleanly) */
+	if ((uint32_t)zz_overlay_bitmap->Planes[0] < (uint32_t)b->MemoryBase ||
+	    (uint32_t)zz_overlay_bitmap->Planes[0] - (uint32_t)b->MemoryBase >=
+	    (uint32_t)b->MemorySize) {
+		KPrintF("ZZ9000: CreateFeature source NOT on board (%08lx)\n",
+			(ULONG)zz_overlay_bitmap->Planes[0]);
+		p96FreeBitMap(zz_overlay_bitmap);
+		zz_overlay_bitmap = NULL;
 		return NULL;
 	}
 
@@ -2244,7 +2258,7 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 			KPrintF("ZZ9000: CreateFeature fw SET status %ld\n",
 				(LONG)fw_status);
 			zz_overlay.magic = 0;
-			ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
+			p96FreeBitMap(zz_overlay_bitmap);
 			zz_overlay_bitmap = NULL;
 			return NULL;
 		}
@@ -2365,7 +2379,7 @@ BOOL ZZ_DeleteFeature(__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0(UL
 
 	zz_overlay_push(b, 1);
 	zz_overlay.magic = 0;
-	ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
+	p96FreeBitMap(zz_overlay_bitmap);
 	zz_overlay_bitmap = NULL;
 
 	return TRUE;

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -2160,11 +2160,6 @@ static struct ZZOverlayState zz_overlay;
 static struct BitMap *zz_overlay_bitmap = NULL;
 /* which allocator made it, so the right one frees it */
 static BOOL zz_overlay_bitmap_p96 = FALSE;
-/* RastPort handed to the app for P96PIP_SourceRPort: wraps the source
- * bitmap; equivalent of InitRastPort defaults, built by hand so the
- * driver needs no graphics.library base */
-static struct RastPort zz_overlay_rport;
-
 static void zz_overlay_free_source(struct BoardInfo *b) {
 	if (!zz_overlay_bitmap)
 		return;
@@ -2310,14 +2305,6 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		zzwrite16(&registers->set_feature_status, 1);
 	}
 
-	memset(&zz_overlay_rport, 0, sizeof(zz_overlay_rport));
-	zz_overlay_rport.BitMap = zz_overlay_bitmap;
-	zz_overlay_rport.Mask = 0xFF;
-	zz_overlay_rport.FgPen = -1;
-	zz_overlay_rport.AOlPen = -1;
-	zz_overlay_rport.LinePtrn = 0xFFFF;
-	zz_overlay_rport.DrawMode = 1; /* JAM2 */
-
 	zz_overlay.magic = ZZ_OVERLAY_MAGIC;
 
 	{
@@ -2395,26 +2382,24 @@ ULONG ZZ_GetFeatureAttrs(__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0
 			case TAG_MORE: tag = (struct TagItem *)tag->ti_Data; continue;
 			default: {
 				uint32_t out;
-				/* the app's p96PIP_GetTags queries arrive here:
-				 * unanswered source-object queries crash the app
-				 * on an undefined pointer */
-				if (have && tag->ti_Tag == ZZ_P96PIP_SOURCEBITMAP) {
-					if (tag->ti_Data)
-						*(ULONG *)tag->ti_Data = (ULONG)zz_overlay_bitmap;
-					count++;
+				/* the app's p96PIP_GetTags source-object queries
+				 * (P96PIP_SourceBitMap/SourceRPort) arrive here too.
+				 * DO NOT answer them - uaegfx parity: WinUAE's
+				 * GetFeatureAttrs handles only FA_* tags and leaves
+				 * these stores alone, and RiVA PIP works there. P96
+				 * constructs the source RastPort/BitMap objects
+				 * itself (around FA_BitMap); a bench where we
+				 * overwrote the stores with the raw bitmap and a
+				 * hand-built RastPort froze the machine at RiVA's
+				 * first LockVLayer over those bare objects. */
+				if (tag->ti_Tag == ZZ_P96PIP_SOURCEBITMAP ||
+				    tag->ti_Tag == ZZ_P96PIP_SOURCERPORT) {
 #ifdef DEBUG
-					KPrintF("ZZ9000: GetFeatureAttrs PIP bitmap -> %08lx\n",
-						(ULONG)zz_overlay_bitmap);
-#endif
-					break;
-				}
-				if (have && tag->ti_Tag == ZZ_P96PIP_SOURCERPORT) {
-					if (tag->ti_Data)
-						*(ULONG *)tag->ti_Data = (ULONG)&zz_overlay_rport;
-					count++;
-#ifdef DEBUG
-					KPrintF("ZZ9000: GetFeatureAttrs PIP rport -> %08lx\n",
-						(ULONG)&zz_overlay_rport);
+					KPrintF("ZZ9000: GetFeatureAttrs PIP query "
+						"%08lx store %08lx prefill %08lx\n",
+						tag->ti_Tag, tag->ti_Data,
+						tag->ti_Data ?
+						*(ULONG *)tag->ti_Data : 0);
 #endif
 					break;
 				}

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -2264,13 +2264,30 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 	KPrintF("ZZ9000: CreateFeature friend VisibleBitMap %08lx\n",
 		(ULONG)b->VisibleBitMap);
 #endif
-	zz_overlay_bitmap = p96AllocBitMap(zz_overlay.src_w,
+	/* HALF the width: P96 sizes the managed bitmap from the friend's
+	 * 4-byte format regardless of the requested YUV format or of
+	 * CalculateBytesPerRow (bench: pitch stayed width*4 with the hook
+	 * answering width*2). RiVA hardcodes its write modulo as width*2
+	 * (cgxvideo has no modulo attribute), so the pitch must be EXACTLY
+	 * that: a half-width allocation lands the friend-derived sizing on
+	 * (width/2)*4 = width*2. The feature keeps the true source
+	 * geometry; only the managed bitmap's nominal width is halved. */
+	zz_overlay_bitmap = p96AllocBitMap((zz_overlay.src_w + 1) / 2,
 		zz_overlay.src_h, 16, BMF_CLEAR, b->VisibleBitMap,
 		(RGBFTYPE)zz_overlay.rgbformat);
 	if (!zz_overlay_bitmap) {
 		KPrintF("ZZ9000: CreateFeature p96AllocBitMap FAILED\n");
 		return NULL;
 	}
+#ifdef DEBUG
+	KPrintF("ZZ9000: CreateFeature bm fmt %ld w %ld bpr %ld bpp %ld p96 %ld onboard %ld\n",
+		p96GetBitMapAttr(zz_overlay_bitmap, P96BMA_RGBFORMAT),
+		p96GetBitMapAttr(zz_overlay_bitmap, P96BMA_WIDTH),
+		p96GetBitMapAttr(zz_overlay_bitmap, P96BMA_BYTESPERROW),
+		p96GetBitMapAttr(zz_overlay_bitmap, P96BMA_BYTESPERPIXEL),
+		p96GetBitMapAttr(zz_overlay_bitmap, P96BMA_ISP96),
+		p96GetBitMapAttr(zz_overlay_bitmap, P96BMA_ISONBOARD));
+#endif
 
 	/* the compositor reads the source from card VRAM: a source the
 	 * friend affinity failed to place on board fails the open cleanly

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -2254,8 +2254,12 @@ ULONG ZZ_SetFeatureAttrs(__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0
 				KPrintF("ZZ9000: SetFeatureAttrs tag=%08lx data=%08lx\n",
 					tag->ti_Tag, tag->ti_Data);
 #endif
-				dirty |= zz_overlay_apply_tag(&zz_overlay, tag->ti_Tag,
-					tag->ti_Data);
+				/* source geometry/format is fixed at CreateFeature:
+				 * the backing bitmap cannot grow under a live
+				 * feature */
+				if (!zz_overlay_tag_create_only(tag->ti_Tag))
+					dirty |= zz_overlay_apply_tag(&zz_overlay,
+						tag->ti_Tag, tag->ti_Data);
 				count++;
 				break;
 		}

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -37,6 +37,8 @@
 #include "blitter_cache.h"
 #include "offscreen_bitmap.h"
 #include "overlay_feature.h"
+#include <clib/Picasso96_protos.h>
+#include <inline/Picasso96.h>
 
 #define STR(s) #s
 #define XSTR(s) STR(s)
@@ -163,20 +165,6 @@ static BOOL zz_overlay_hooks_enabled = FALSE;
  * still inside the autoconfig window. Ownership/on-board checks must
  * bound Planes[0] against this, never against b->MemorySize. */
 static ULONG zz_card_window_size = 0;
-/* rtg.library's own AllocBitMap/FreeBitMap, captured from the
- * BoardInfo before InitCard installs the ZZ hooks. The PIP source
- * bitmap must come from THIS constructor when available: it returns a
- * bitmap P96 fully manages, placed inside the board window
- * [MemoryBase..MemorySize] that P96's bitmap bookkeeping (board
- * lookups in the LockVLayer/PIP paths) can attribute to this board.
- * Our surface-heap bitmaps sit above that window, which P96's
- * internals cannot attribute to any board. This is the PicassoIV
- * contract: its CreateFeature calls bi->AllocBitMap - the library
- * default, since it installs no hook of its own. */
-static struct BitMap * ASM (*zz_p96_alloc_bitmap)(__REGA0(struct BoardInfo *),
-	__REGD0(ULONG), __REGD1(ULONG), __REGA1(struct TagItem *)) = NULL;
-static BOOL ASM (*zz_p96_free_bitmap)(__REGA0(struct BoardInfo *),
-	__REGA1(struct BitMap *), __REGA2(struct TagItem *)) = NULL;
 
 static inline volatile struct GFXData *zz_gfxdata(struct BoardInfo *b) {
 	return (volatile struct GFXData *)b->CardData[ZZ_CARD_DATA_GFXDATA];
@@ -898,15 +886,6 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 		const char *value = tooltype_value(tool_types, "OFFSCREENBITMAPS");
 		if (value)
 			offscreen = !value_is_false(value);
-		/* capture the library defaults (NULL if rtg.library fills
-		 * them only after InitCard) before installing our hooks;
-		 * ZZ_CreateFeature prefers the saved constructor */
-		zz_p96_alloc_bitmap = b->AllocBitMap;
-		zz_p96_free_bitmap = b->FreeBitMap;
-#ifdef DEBUG
-		KPrintF("ZZ9000: InitCard P96 AllocBitMap=%08lx FreeBitMap=%08lx\n",
-			(ULONG)zz_p96_alloc_bitmap, (ULONG)zz_p96_free_bitmap);
-#endif
 		if (offscreen && fwrev >= OFFSCREEN_BITMAPS_MIN_FWREV &&
 				(b->CardFlags & CARDFLAG_ZORRO_3)) {
 			b->AllocBitMap = (void *)ZZ_AllocBitMap;
@@ -2152,23 +2131,37 @@ int ZZ_WriteYUVRect(__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHO
 /* --- P96 video window (PIP) Features API -----------------------------
  * Contract modeled on WinUAE's uaegfx overlay (the only public
  * reference): P96 creates the PIP as an SFT_MEMORYWINDOW feature, the
- * driver allocates the YUV source bitmap through its own AllocBitMap
- * and the firmware composites it into the display (OP_VIDEO_OVERLAY +
- * shadow scanout). One overlay at a time. */
+ * driver supplies a YUV source bitmap and the firmware composites it
+ * into the display (OP_VIDEO_OVERLAY + shadow scanout). One overlay
+ * at a time.
+ *
+ * The source bitmap MUST be P96-MANAGED (from p96AllocBitMap, in
+ * rtg.library's own bookkeeping): every bench round that handed out a
+ * bare driver-cooked bitmap froze the machine at RiVA's first
+ * LockVLayer (P96's cgxvideo emulation walks its bitmap bookkeeping),
+ * while the round with a p96AllocBitMap source played video through
+ * the software path. On-board placement comes from a FRIEND bitmap
+ * with board affinity: b->VisibleBitMap, the displayed screen's
+ * bitmap, which P96 maintains in the BoardInfo - Intuition-free, so
+ * no LockPubScreen deadlock (that variant froze CreateFeature). A
+ * source P96 still places in system RAM fails the open cleanly into
+ * P96's software PIP instead of risking the frozen hardware path. */
 
 static struct ZZOverlayState zz_overlay;
 static struct BitMap *zz_overlay_bitmap = NULL;
-/* which allocator made it, so the right one frees it */
-static BOOL zz_overlay_bitmap_p96 = FALSE;
+static struct Library *P96Base = NULL;
+/* RastPort handed to the app for P96PIP_SourceRPort (the prefill=0
+ * capture proved P96 does NOT construct the source objects itself):
+ * wraps the managed source bitmap; InitRastPort defaults built by
+ * hand so the driver needs no graphics.library base. Proven safe with
+ * a managed bitmap - RiVA played video through exactly this pair. */
+static struct RastPort zz_overlay_rport;
 static void zz_overlay_free_source(struct BoardInfo *b) {
+	(void)b;
 	if (!zz_overlay_bitmap)
 		return;
-	if (zz_overlay_bitmap_p96 && zz_p96_free_bitmap)
-		zz_p96_free_bitmap(b, zz_overlay_bitmap, NULL);
-	else
-		ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
+	p96FreeBitMap(zz_overlay_bitmap);
 	zz_overlay_bitmap = NULL;
-	zz_overlay_bitmap_p96 = FALSE;
 }
 
 /* Push the full overlay state (or OFF) to the firmware; returns the
@@ -2244,56 +2237,35 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		return NULL;
 	}
 
-	/* Allocate the YUV source with the PicassoIV tag set
-	 * (ABMA_Displayable/Visible/Clear - the tags WinUAE's uaegfx
-	 * CreateFeature copied from the PicassoIV driver, which calls
-	 * bi->AllocBitMap exactly like this). PREFER the saved rtg.library
-	 * constructor: it returns a bitmap P96 fully manages, inside the
-	 * board window its bookkeeping can attribute to this board. A
-	 * bench with the source in our surface heap (outside every board
-	 * window) froze the machine at the activating SetFeatureAttrs -
-	 * the moment RiVA's first LockVLayer runs over P96's bitmap
-	 * bookkeeping. Fall back to our own hook (board-pinned surface
-	 * heap) when the library default was not captured. */
-	{
-		struct TagItem alloc_tags[5];
-		alloc_tags[0].ti_Tag = ABMA_RGBFormat;
-		alloc_tags[0].ti_Data = zz_overlay.rgbformat;
-		alloc_tags[1].ti_Tag = ABMA_Clear;
-		alloc_tags[1].ti_Data = 1;
-		alloc_tags[2].ti_Tag = ABMA_Displayable;
-		alloc_tags[2].ti_Data = 1;
-		alloc_tags[3].ti_Tag = ABMA_Visible;
-		alloc_tags[3].ti_Data = 1;
-		alloc_tags[4].ti_Tag = TAG_DONE;
-		alloc_tags[4].ti_Data = 0;
-
-		zz_overlay_bitmap_p96 = FALSE;
-		if (zz_p96_alloc_bitmap) {
-			zz_overlay_bitmap = zz_p96_alloc_bitmap(b,
-				zz_overlay.src_w, zz_overlay.src_h, alloc_tags);
-			if (zz_overlay_bitmap) {
-				zz_overlay_bitmap_p96 = TRUE;
-			} else {
-				KPrintF("ZZ9000: CreateFeature P96 AllocBitMap "
-					"declined, using ZZ hook\n");
-			}
-		}
-		if (!zz_overlay_bitmap)
-			zz_overlay_bitmap = ZZ_AllocBitMap(b, zz_overlay.src_w,
-				zz_overlay.src_h, alloc_tags);
+	/* P96-managed source (see the block comment above the statics):
+	 * p96AllocBitMap with b->VisibleBitMap as the friend for board
+	 * affinity. No BMF_DISPLAYABLE - a displayable YUV request has no
+	 * display mode and lands in system RAM; the friend is what pins
+	 * the board. */
+	if (!P96Base)
+		P96Base = OpenLibrary((APTR)"Picasso96API.library", 2);
+	if (!P96Base) {
+		KPrintF("ZZ9000: CreateFeature: no Picasso96API.library\n");
+		return NULL;
 	}
+#ifdef DEBUG
+	KPrintF("ZZ9000: CreateFeature friend VisibleBitMap %08lx\n",
+		(ULONG)b->VisibleBitMap);
+#endif
+	zz_overlay_bitmap = p96AllocBitMap(zz_overlay.src_w,
+		zz_overlay.src_h, 16, BMF_CLEAR, b->VisibleBitMap,
+		(RGBFTYPE)zz_overlay.rgbformat);
 	if (!zz_overlay_bitmap) {
-		KPrintF("ZZ9000: CreateFeature AllocBitMap FAILED\n");
+		KPrintF("ZZ9000: CreateFeature p96AllocBitMap FAILED\n");
 		return NULL;
 	}
 
-	/* the compositor reads the source from card VRAM; ZZ_AllocBitMap
-	 * guarantees that, so this is a belt-and-braces diagnostic. The
-	 * bound is the autoconfig window, NOT b->MemorySize: the firmware
-	 * surface heap sits above the P96 window (see zz_card_window_size),
-	 * which a previous MemorySize-based check here misread as a
-	 * system-RAM placement. */
+	/* the compositor reads the source from card VRAM: a source the
+	 * friend affinity failed to place on board fails the open cleanly
+	 * into P96's software PIP. The bound is the autoconfig window, NOT
+	 * b->MemorySize: the firmware surface heap sits above the P96
+	 * window (see zz_card_window_size), which a previous
+	 * MemorySize-based check here misread as a system-RAM placement. */
 	if ((uint32_t)zz_overlay_bitmap->Planes[0] < (uint32_t)b->MemoryBase ||
 	    (uint32_t)zz_overlay_bitmap->Planes[0] - (uint32_t)b->MemoryBase >=
 	    (uint32_t)zz_card_window_size) {
@@ -2309,6 +2281,14 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		zzwrite16(&registers->blitter_user1, CARD_FEATURE_VIDEO_OVERLAY);
 		zzwrite16(&registers->set_feature_status, 1);
 	}
+
+	memset(&zz_overlay_rport, 0, sizeof(zz_overlay_rport));
+	zz_overlay_rport.BitMap = zz_overlay_bitmap;
+	zz_overlay_rport.Mask = 0xFF;
+	zz_overlay_rport.FgPen = -1;
+	zz_overlay_rport.AOlPen = -1;
+	zz_overlay_rport.LinePtrn = 0xFFFF;
+	zz_overlay_rport.DrawMode = 1; /* JAM2 */
 
 	zz_overlay.magic = ZZ_OVERLAY_MAGIC;
 
@@ -2387,24 +2367,28 @@ ULONG ZZ_GetFeatureAttrs(__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0
 			case TAG_MORE: tag = (struct TagItem *)tag->ti_Data; continue;
 			default: {
 				uint32_t out;
-				/* the app's p96PIP_GetTags source-object queries
-				 * (P96PIP_SourceBitMap/SourceRPort) arrive here too.
-				 * DO NOT answer them - uaegfx parity: WinUAE's
-				 * GetFeatureAttrs handles only FA_* tags and leaves
-				 * these stores alone, and RiVA PIP works there. P96
-				 * constructs the source RastPort/BitMap objects
-				 * itself (around FA_BitMap); a bench where we
-				 * overwrote the stores with the raw bitmap and a
-				 * hand-built RastPort froze the machine at RiVA's
-				 * first LockVLayer over those bare objects. */
-				if (tag->ti_Tag == ZZ_P96PIP_SOURCEBITMAP ||
-				    tag->ti_Tag == ZZ_P96PIP_SOURCERPORT) {
+				/* the app's p96PIP_GetTags source-object queries:
+				 * P96 does NOT construct these itself (a capture
+				 * showed the stores arrive zeroed), so answer with
+				 * the managed bitmap and the RastPort wrapping it -
+				 * the pair RiVA demonstrably played video through. */
+				if (have && tag->ti_Tag == ZZ_P96PIP_SOURCEBITMAP) {
+					if (tag->ti_Data)
+						*(ULONG *)tag->ti_Data = (ULONG)zz_overlay_bitmap;
+					count++;
 #ifdef DEBUG
-					KPrintF("ZZ9000: GetFeatureAttrs PIP query "
-						"%08lx store %08lx prefill %08lx\n",
-						tag->ti_Tag, tag->ti_Data,
-						tag->ti_Data ?
-						*(ULONG *)tag->ti_Data : 0);
+					KPrintF("ZZ9000: GetFeatureAttrs PIP bitmap -> %08lx\n",
+						(ULONG)zz_overlay_bitmap);
+#endif
+					break;
+				}
+				if (have && tag->ti_Tag == ZZ_P96PIP_SOURCERPORT) {
+					if (tag->ti_Data)
+						*(ULONG *)tag->ti_Data = (ULONG)&zz_overlay_rport;
+					count++;
+#ifdef DEBUG
+					KPrintF("ZZ9000: GetFeatureAttrs PIP rport -> %08lx\n",
+						(ULONG)&zz_overlay_rport);
 #endif
 					break;
 				}

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -2204,6 +2204,11 @@ static ULONG zz_overlay_push(struct BoardInfo *b, int off) {
 }
 
 APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1(struct TagItem *tags)) {
+#ifdef DEBUG
+	/* build fingerprint: identifies the exact binary in every capture
+	 * (three bench rounds in a row ran a stale card unnoticed) */
+	KPrintF("ZZ9000: CreateFeature build " __DATE__ " " __TIME__ "\n");
+#endif
 	if (!b || type != SFT_MEMORYWINDOW)
 		return NULL;
 	if (zz_overlay_bitmap)

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -163,6 +163,20 @@ static BOOL zz_overlay_hooks_enabled = FALSE;
  * still inside the autoconfig window. Ownership/on-board checks must
  * bound Planes[0] against this, never against b->MemorySize. */
 static ULONG zz_card_window_size = 0;
+/* rtg.library's own AllocBitMap/FreeBitMap, captured from the
+ * BoardInfo before InitCard installs the ZZ hooks. The PIP source
+ * bitmap must come from THIS constructor when available: it returns a
+ * bitmap P96 fully manages, placed inside the board window
+ * [MemoryBase..MemorySize] that P96's bitmap bookkeeping (board
+ * lookups in the LockVLayer/PIP paths) can attribute to this board.
+ * Our surface-heap bitmaps sit above that window, which P96's
+ * internals cannot attribute to any board. This is the PicassoIV
+ * contract: its CreateFeature calls bi->AllocBitMap - the library
+ * default, since it installs no hook of its own. */
+static struct BitMap * ASM (*zz_p96_alloc_bitmap)(__REGA0(struct BoardInfo *),
+	__REGD0(ULONG), __REGD1(ULONG), __REGA1(struct TagItem *)) = NULL;
+static BOOL ASM (*zz_p96_free_bitmap)(__REGA0(struct BoardInfo *),
+	__REGA1(struct BitMap *), __REGA2(struct TagItem *)) = NULL;
 
 static inline volatile struct GFXData *zz_gfxdata(struct BoardInfo *b) {
 	return (volatile struct GFXData *)b->CardData[ZZ_CARD_DATA_GFXDATA];
@@ -884,6 +898,15 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 		const char *value = tooltype_value(tool_types, "OFFSCREENBITMAPS");
 		if (value)
 			offscreen = !value_is_false(value);
+		/* capture the library defaults (NULL if rtg.library fills
+		 * them only after InitCard) before installing our hooks;
+		 * ZZ_CreateFeature prefers the saved constructor */
+		zz_p96_alloc_bitmap = b->AllocBitMap;
+		zz_p96_free_bitmap = b->FreeBitMap;
+#ifdef DEBUG
+		KPrintF("ZZ9000: InitCard P96 AllocBitMap=%08lx FreeBitMap=%08lx\n",
+			(ULONG)zz_p96_alloc_bitmap, (ULONG)zz_p96_free_bitmap);
+#endif
 		if (offscreen && fwrev >= OFFSCREEN_BITMAPS_MIN_FWREV &&
 				(b->CardFlags & CARDFLAG_ZORRO_3)) {
 			b->AllocBitMap = (void *)ZZ_AllocBitMap;
@@ -2135,10 +2158,23 @@ int ZZ_WriteYUVRect(__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHO
 
 static struct ZZOverlayState zz_overlay;
 static struct BitMap *zz_overlay_bitmap = NULL;
+/* which allocator made it, so the right one frees it */
+static BOOL zz_overlay_bitmap_p96 = FALSE;
 /* RastPort handed to the app for P96PIP_SourceRPort: wraps the source
  * bitmap; equivalent of InitRastPort defaults, built by hand so the
  * driver needs no graphics.library base */
 static struct RastPort zz_overlay_rport;
+
+static void zz_overlay_free_source(struct BoardInfo *b) {
+	if (!zz_overlay_bitmap)
+		return;
+	if (zz_overlay_bitmap_p96 && zz_p96_free_bitmap)
+		zz_p96_free_bitmap(b, zz_overlay_bitmap, NULL);
+	else
+		ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
+	zz_overlay_bitmap = NULL;
+	zz_overlay_bitmap_p96 = FALSE;
+}
 
 /* Push the full overlay state (or OFF) to the firmware; returns the
  * firmware status word (0 = OK). */
@@ -2208,19 +2244,17 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		return NULL;
 	}
 
-	/* Allocate the YUV source through our own AllocBitMap hook with
-	 * the PicassoIV tag set (ABMA_Displayable/Visible/Clear - the tags
-	 * WinUAE's uaegfx CreateFeature copied from the PicassoIV driver,
-	 * which calls bi->AllocBitMap exactly like this). Board-pinned by
-	 * construction, so the source always lands in card VRAM. The
-	 * p96AllocBitMap detours were dead ends: without a friend it
-	 * places non-screen bitmaps in system RAM even with
-	 * BMF_DISPLAYABLE (no YUV display mode exists), and a
-	 * LockPubScreen friend deadlocks inside CreateFeature (P96 calls
-	 * us holding locks the pubscreen path contends on). The bare
-	 * bitmap is fine: rtg.library wraps feature bitmaps itself, the
-	 * same way every off-screen bitmap from this hook becomes
-	 * P96-managed. */
+	/* Allocate the YUV source with the PicassoIV tag set
+	 * (ABMA_Displayable/Visible/Clear - the tags WinUAE's uaegfx
+	 * CreateFeature copied from the PicassoIV driver, which calls
+	 * bi->AllocBitMap exactly like this). PREFER the saved rtg.library
+	 * constructor: it returns a bitmap P96 fully manages, inside the
+	 * board window its bookkeeping can attribute to this board. A
+	 * bench with the source in our surface heap (outside every board
+	 * window) froze the machine at the activating SetFeatureAttrs -
+	 * the moment RiVA's first LockVLayer runs over P96's bitmap
+	 * bookkeeping. Fall back to our own hook (board-pinned surface
+	 * heap) when the library default was not captured. */
 	{
 		struct TagItem alloc_tags[5];
 		alloc_tags[0].ti_Tag = ABMA_RGBFormat;
@@ -2234,8 +2268,20 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		alloc_tags[4].ti_Tag = TAG_DONE;
 		alloc_tags[4].ti_Data = 0;
 
-		zz_overlay_bitmap = ZZ_AllocBitMap(b, zz_overlay.src_w,
-			zz_overlay.src_h, alloc_tags);
+		zz_overlay_bitmap_p96 = FALSE;
+		if (zz_p96_alloc_bitmap) {
+			zz_overlay_bitmap = zz_p96_alloc_bitmap(b,
+				zz_overlay.src_w, zz_overlay.src_h, alloc_tags);
+			if (zz_overlay_bitmap) {
+				zz_overlay_bitmap_p96 = TRUE;
+			} else {
+				KPrintF("ZZ9000: CreateFeature P96 AllocBitMap "
+					"declined, using ZZ hook\n");
+			}
+		}
+		if (!zz_overlay_bitmap)
+			zz_overlay_bitmap = ZZ_AllocBitMap(b, zz_overlay.src_w,
+				zz_overlay.src_h, alloc_tags);
 	}
 	if (!zz_overlay_bitmap) {
 		KPrintF("ZZ9000: CreateFeature AllocBitMap FAILED\n");
@@ -2253,8 +2299,7 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 	    (uint32_t)zz_card_window_size) {
 		KPrintF("ZZ9000: CreateFeature source NOT on board (%08lx)\n",
 			(ULONG)zz_overlay_bitmap->Planes[0]);
-		ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
-		zz_overlay_bitmap = NULL;
+		zz_overlay_free_source(b);
 		return NULL;
 	}
 
@@ -2281,8 +2326,7 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 			KPrintF("ZZ9000: CreateFeature fw SET status %ld\n",
 				(LONG)fw_status);
 			zz_overlay.magic = 0;
-			ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
-			zz_overlay_bitmap = NULL;
+			zz_overlay_free_source(b);
 			return NULL;
 		}
 	}
@@ -2402,8 +2446,7 @@ BOOL ZZ_DeleteFeature(__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0(UL
 
 	zz_overlay_push(b, 1);
 	zz_overlay.magic = 0;
-	ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
-	zz_overlay_bitmap = NULL;
+	zz_overlay_free_source(b);
 
 	return TRUE;
 }

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -1184,6 +1184,15 @@ uint16_t pitch_to_shift(uint16_t p) {
 UWORD CalculateBytesPerRow(__REGA0(struct BoardInfo *b), __REGA1(struct ModeInfo *mode_info), __REGD0(UWORD width), __REGD1(UWORD height), __REGD7(RGBFTYPE format)) {
 	if (!b)
 		return 0;
+	/* packed YUV 4:2:2 PIP sources are 2 bytes/pixel, and the pitch
+	 * MUST be exactly width*2: P96 sizes the managed source bitmap
+	 * through this hook (returning 0 made it fall back to 4
+	 * bytes/pixel), and RiVA hardcodes its write modulo as width*2
+	 * because cgxvideo has no modulo attribute (RendererCGXInit.i,
+	 * "modulo.... (cgx sux!)") - any padding breaks every VLayer
+	 * writer with that assumption */
+	if (zz_overlay_hooks_enabled && zz_overlay_variant(format) >= 0)
+		return (UWORD)zz_offscreen_bytes_per_row(format, width);
 	if (!supported_rgb_format(format))
 		return 0;
 
@@ -1191,7 +1200,10 @@ UWORD CalculateBytesPerRow(__REGA0(struct BoardInfo *b), __REGA1(struct ModeInfo
 }
 
 APTR CalculateMemory(__REGA0(struct BoardInfo *b), __REGA1(APTR addr), __REGD0(struct RenderInfo *r), __REGD7(RGBFTYPE format)) {
-	if (!b || !supported_rgb_format(format))
+	if (!b)
+		return NULL;
+	if (!supported_rgb_format(format) &&
+			!(zz_overlay_hooks_enabled && zz_overlay_variant(format) >= 0))
 		return NULL;
 
 	return addr;

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -841,7 +841,9 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 	//b->AllocCardMemAbs = (void *)NULL;
 	b->SetSplitPosition = (void *)SetSplitPosition;
 	//b->ReInitMemory = (void *)NULL;
-	//b->WriteYUVRect = (void *)NULL;
+	/* Stage A contract probe: logs + delegates to WriteYUVRectDefault
+	 * (pure pass-through in release builds). See ZZ_WriteYUVRect. */
+	b->WriteYUVRect = (void *)ZZ_WriteYUVRect;
 	b->GetVSyncState = (void *)GetVSyncState;
 	//b->GetVBeamPos = (void *)NULL;
 	//b->SetDPMSLevel = (void *)NULL;
@@ -2005,6 +2007,69 @@ ULONG ZZ_GetBitMapAttr(__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm),
 	}
 
 	return zz_offscreen_attr(&attrs, attr);
+}
+
+/* WriteYUVRect contract probe (Stage A). P96 calls this hook from its
+ * software picture-in-picture path (p96PIP with a YUV source), but the
+ * TagItem contract - how the source stride and format arrive - is
+ * undocumented and P96's source is closed. This probe logs every
+ * argument, the full tag list and the head of the source data, then
+ * delegates to P96's own converter, so a Sashimi capture from a real
+ * PIP session defines the contract the accelerated implementation will
+ * code against. Build with -DDEBUG (and -ldebug) to enable the
+ * logging; a release build is a pure pass-through. */
+int ZZ_WriteYUVRect(__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHORT srcx), __REGD1(SHORT srcy), __REGA2(struct RenderInfo *r), __REGD2(SHORT dstx), __REGD3(SHORT dsty), __REGD4(SHORT w), __REGD5(SHORT h), __REGA3(struct TagItem *tags)) {
+	int result;
+#ifdef DEBUG
+	static ULONG yuv_calls = 0;
+	ULONG n = yuv_calls++;
+	int do_log = (n < 8) || ((n & 0xFF) == 0);
+
+	if (do_log) {
+		KPrintF("ZZ9000: WriteYUVRect #%ld src=%lx sx=%ld sy=%ld dst=%lx bpr=%ld fmt=%ld dx=%ld dy=%ld w=%ld h=%ld tags=%lx\n",
+			n, (ULONG)src, (LONG)srcx, (LONG)srcy,
+			(ULONG)(r ? (ULONG)r->Memory : 0),
+			(LONG)(r ? r->BytesPerRow : 0),
+			(LONG)(r ? (LONG)r->RGBFormat : -1),
+			(LONG)dstx, (LONG)dsty, (LONG)w, (LONG)h, (ULONG)tags);
+
+		struct TagItem *tag = tags;
+		int guard = 32;
+		while (tag && tag->ti_Tag != TAG_DONE && guard--) {
+			switch (tag->ti_Tag) {
+				case TAG_IGNORE: break;
+				case TAG_SKIP: tag += tag->ti_Data; break;
+				case TAG_MORE: tag = (struct TagItem *)tag->ti_Data; continue;
+				default:
+					KPrintF("ZZ9000:   tag=%08lx data=%08lx\n",
+						tag->ti_Tag, tag->ti_Data);
+					break;
+			}
+			tag++;
+		}
+
+		if (src) {
+			const UBYTE *p = (const UBYTE *)src;
+			KPrintF("ZZ9000:   src[0..7]=%02lx %02lx %02lx %02lx %02lx %02lx %02lx %02lx\n",
+				(ULONG)p[0], (ULONG)p[1], (ULONG)p[2], (ULONG)p[3],
+				(ULONG)p[4], (ULONG)p[5], (ULONG)p[6], (ULONG)p[7]);
+			KPrintF("ZZ9000:   src[8..15]=%02lx %02lx %02lx %02lx %02lx %02lx %02lx %02lx\n",
+				(ULONG)p[8], (ULONG)p[9], (ULONG)p[10], (ULONG)p[11],
+				(ULONG)p[12], (ULONG)p[13], (ULONG)p[14], (ULONG)p[15]);
+		}
+	}
+#endif
+
+	if (!b->WriteYUVRectDefault)
+		return 0;
+	result = b->WriteYUVRectDefault(b, src, srcx, srcy, r, dstx, dsty, w, h, tags);
+
+#ifdef DEBUG
+	if (do_log)
+		KPrintF("ZZ9000:   WriteYUVRectDefault returned %ld\n", (LONG)result);
+#endif
+
+	return result;
 }
 
 // This function shall blit a planar bitmap anywhere in the 68K address space into a chunky bitmap in video RAM.

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -36,6 +36,7 @@
 #include "zzcfg_query.h"
 #include "blitter_cache.h"
 #include "offscreen_bitmap.h"
+#include "overlay_feature.h"
 
 #define STR(s) #s
 #define XSTR(s) STR(s)
@@ -120,8 +121,11 @@ char dummies[128];
 #define ZZ_CARD_DATA_DISPLAY_ENABLED 4
 #define ZZ_CARD_DATA_SECONDARY_PALETTE 5
 #define ZZ_CARD_DATA_OFFSCREEN_BITMAPS 6
+#define ZZ_CARD_DATA_VIDEO_OVERLAY 7
 /* first firmware whose surface allocator really frees (major<<8|minor) */
 #define OFFSCREEN_BITMAPS_MIN_FWREV 0x0204
+/* first firmware with OP_VIDEO_OVERLAY + the shadow-scanout compositor */
+#define VIDEO_OVERLAY_MIN_FWREV 0x0206
 #define MNT_MANUFACTURER 0x6d6e
 #define ZZ9000_PRODUCT_Z2 0x3
 #define ZZ9000_PRODUCT_Z3 0x4
@@ -151,6 +155,7 @@ char dummies[128];
 struct ExecBase *SysBase;
 static struct ConfigDev *reserved_cd = NULL;
 static struct BlitterRegisterCache blitter_register_cache;
+static BOOL zz_overlay_hooks_enabled = FALSE;
 
 static inline volatile struct GFXData *zz_gfxdata(struct BoardInfo *b) {
 	return (volatile struct GFXData *)b->CardData[ZZ_CARD_DATA_GFXDATA];
@@ -652,6 +657,7 @@ int __attribute__((used)) FindCard(__REGA0(struct BoardInfo* b)) {
 	b->CardData[ZZ_CARD_DATA_DISPLAY_ENABLED] = 1;
 	b->CardData[ZZ_CARD_DATA_SECONDARY_PALETTE] = 0;
 	b->CardData[ZZ_CARD_DATA_OFFSCREEN_BITMAPS] = 1;
+	b->CardData[ZZ_CARD_DATA_VIDEO_OVERLAY] = 1;
 	if ((cd = find_unconfigured_configdev(ExpansionBase, MNT_MANUFACTURER, ZZ9000_PRODUCT_Z3))) zorro_version = 3;
 	else if ((cd = find_unconfigured_configdev(ExpansionBase, MNT_MANUFACTURER, ZZ9000_PRODUCT_Z2))) zorro_version = 2;
 
@@ -745,6 +751,15 @@ int __attribute__((used)) FindCard(__REGA0(struct BoardInfo* b)) {
 				ZZ_CFG_KEY_OFFSCREEN_BITMAPS, &cfg_present);
 			if (cfg_present)
 				b->CardData[ZZ_CARD_DATA_OFFSCREEN_BITMAPS] = (cfg_value != 0);
+		}
+
+		if (env_flag_exists(DOSBase, "ENV:ZZ9000-NO-PIP")) {
+			b->CardData[ZZ_CARD_DATA_VIDEO_OVERLAY] = 0;
+		} else {
+			cfg_value = zzcfg_query((ULONG)b->RegisterBase,
+				ZZ_CFG_KEY_VIDEO_OVERLAY, &cfg_present);
+			if (cfg_present)
+				b->CardData[ZZ_CARD_DATA_VIDEO_OVERLAY] = (cfg_value != 0);
 		}
 
 		apply_vcap_settings(registers, (LONG)b->CardData[ZZ_CARD_DATA_SCANDBL_800X600]);
@@ -848,7 +863,6 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 	//b->GetVBeamPos = (void *)NULL;
 	//b->SetDPMSLevel = (void *)NULL;
 	//b->ResetChip = (void *)NULL;
-	//b->GetFeatureAttrs = (void *)NULL;
 	/* Off-screen bitmaps in card VRAM (Z3 only; ZZ_AllocBitMap refuses
 	 * on Z2). Requires firmware 2.4+: its surface allocator actually
 	 * frees, while older firmware bump-allocates with a no-op free and
@@ -875,9 +889,28 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 	b->SetSpriteImage = (void *)SetSpriteImage;
 	b->SetSpriteColor = (void *)SetSpriteColor;
 
-	//b->CreateFeature = (void *)NULL;
-	//b->SetFeatureAttrs = (void *)NULL;
-	//b->DeleteFeature = (void *)NULL;
+	/* P96 video window (PIP): Features API + BIF_VIDEOWINDOW. Requires
+	 * firmware 2.6+ (OP_VIDEO_OVERLAY compositor) and the off-screen
+	 * bitmap hooks (CreateFeature allocates the YUV source through
+	 * AllocBitMap). Kill switch: ENV:ZZ9000-NO-PIP, the ZZ9000.CFG
+	 * video_overlay key (both read in FindCard), or the VIDEOPIP
+	 * tooltype, which wins over both. */
+	{
+		UWORD fwrev = ((volatile uint16_t*)b->RegisterBase)[0xC0/2];
+		BOOL pip = (BOOL)b->CardData[ZZ_CARD_DATA_VIDEO_OVERLAY];
+		const char *value = tooltype_value(tool_types, "VIDEOPIP");
+		if (value)
+			pip = !value_is_false(value);
+		if (pip && fwrev >= VIDEO_OVERLAY_MIN_FWREV &&
+				(b->CardFlags & CARDFLAG_ZORRO_3) && b->AllocBitMap) {
+			b->Flags |= BIF_VIDEOWINDOW;
+			b->GetFeatureAttrs = (void *)ZZ_GetFeatureAttrs;
+			b->CreateFeature = (void *)ZZ_CreateFeature;
+			b->SetFeatureAttrs = (void *)ZZ_SetFeatureAttrs;
+			b->DeleteFeature = (void *)ZZ_DeleteFeature;
+			zz_overlay_hooks_enabled = TRUE;
+		}
+	}
 
 	apply_card_settings(b, tool_types);
 	blitter_cache_reset(&blitter_register_cache);
@@ -1155,10 +1188,17 @@ APTR CalculateMemory(__REGA0(struct BoardInfo *b), __REGA1(APTR addr), __REGD0(s
 }
 
 ULONG GetCompatibleFormats(__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE format)) {
-	if (!supported_rgb_format(format))
+	ULONG mask = b ? b->RGBFormats : ZZ_SUPPORTED_RGB_FORMATS;
+
+	/* the packed YUV formats are valid PIP overlay SOURCES (never
+	 * framebuffer formats; b->RGBFormats stays untouched) */
+	if (zz_overlay_hooks_enabled)
+		mask |= ZZ_OVERLAY_SOURCE_FORMATS;
+
+	if (format >= 32 || !(mask & (1UL << format)))
 		return 0;
 
-	return b ? b->RGBFormats : ZZ_SUPPORTED_RGB_FORMATS;
+	return mask;
 }
 
 UWORD SetDisplay(__REGA0(struct BoardInfo *b), __REGD0(UWORD enabled)) {
@@ -1916,8 +1956,11 @@ struct BitMap * ZZ_AllocBitMap(__REGA0(struct BoardInfo *b), __REGD0(ULONG width
 	if (constant_pitch && mode_width > pitch_width)
 		pitch_width = mode_width;
 
+	/* pitch computed locally rather than via CalculateBytesPerRow: the
+	 * P96-facing callback sizes display modes and stays YUV-blind,
+	 * while this path also allocates YUV overlay source bitmaps */
 	uint16_t bytesperrow = zz_offscreen_pad_pitch_to(
-		CalculateBytesPerRow(b, NULL, pitch_width, height, rgbformat),
+		zz_offscreen_bytes_per_row(rgbformat, pitch_width),
 		pitch_align);
 	uint32_t size = (uint32_t)bytesperrow * height;
 	if (!size) return NULL;
@@ -2070,6 +2113,209 @@ int ZZ_WriteYUVRect(__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHO
 #endif
 
 	return result;
+}
+
+
+/* --- P96 video window (PIP) Features API -----------------------------
+ * Contract modeled on WinUAE's uaegfx overlay (the only public
+ * reference): P96 creates the PIP as an SFT_MEMORYWINDOW feature, the
+ * driver allocates the YUV source bitmap through its own AllocBitMap
+ * and the firmware composites it into the display (OP_VIDEO_OVERLAY +
+ * shadow scanout). One overlay at a time. */
+
+static struct ZZOverlayState zz_overlay;
+static struct BitMap *zz_overlay_bitmap = NULL;
+
+/* Push the full overlay state (or OFF) to the firmware; returns the
+ * firmware status word (0 = OK). */
+static ULONG zz_overlay_push(struct BoardInfo *b, int off) {
+	MNTZZ9KRegs* registers = (MNTZZ9KRegs*)b->RegisterBase;
+
+	dmy_cache
+	if (off) {
+		gfxdata->u8_user[GFXDATA_U8_OVERLAY_SUBCMD] = OVERLAY_SUBCMD_OFF;
+	} else {
+		gfxdata->u8_user[GFXDATA_U8_OVERLAY_SUBCMD] = OVERLAY_SUBCMD_SET;
+		gfxdata->u8_user[GFXDATA_U8_YUV_VARIANT] =
+			(uint8_t)zz_overlay_variant(zz_overlay.rgbformat);
+		gfxdata->offset[1] = (uint32_t)zz_overlay_bitmap->Planes[0] -
+			(uint32_t)b->MemoryBase;
+		gfxdata->pitch[1] = zz_overlay_bitmap->BytesPerRow;
+		gfxdata->x[0] = (UWORD)zz_overlay.dst_x;
+		gfxdata->y[0] = (UWORD)zz_overlay.dst_y;
+		gfxdata->x[1] = (UWORD)zz_overlay.dst_w;
+		gfxdata->y[1] = (UWORD)zz_overlay.dst_h;
+		gfxdata->x[2] = zz_overlay.src_w;
+		gfxdata->y[2] = zz_overlay.src_h;
+		gfxdata->user[0] = (UWORD)((zz_overlay.occlusion ? 1 : 0) |
+			(zz_overlay.active ? 2 : 0));
+		/* pen convention: written as the raw 68k ULONG, the firmware
+		 * reads it unswapped (see overlay_handle_op) */
+		gfxdata->u32_user[1] = zz_overlay.color_key;
+	}
+	zzwrite16(&registers->blitter_dma_op, OP_VIDEO_OVERLAY);
+
+	return gfxdata->u32_user[0];
+}
+
+APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1(struct TagItem *tags)) {
+	if (!b || type != SFT_MEMORYWINDOW)
+		return NULL;
+	if (zz_overlay_bitmap)
+		return NULL; /* one overlay at a time (WinUAE parity) */
+	if (!(b->CardFlags & CARDFLAG_ZORRO_3) || !b->AllocBitMap)
+		return NULL;
+
+	memset(&zz_overlay, 0, sizeof(zz_overlay));
+
+	struct TagItem *tag = tags;
+	int guard = 64;
+	while (tag && tag->ti_Tag != TAG_DONE && guard--) {
+		switch (tag->ti_Tag) {
+			case TAG_IGNORE: break;
+			case TAG_SKIP: tag += tag->ti_Data; break;
+			case TAG_MORE: tag = (struct TagItem *)tag->ti_Data; continue;
+			default:
+#ifdef DEBUG
+				KPrintF("ZZ9000: CreateFeature tag=%08lx data=%08lx\n",
+					tag->ti_Tag, tag->ti_Data);
+#endif
+				zz_overlay_apply_tag(&zz_overlay, tag->ti_Tag, tag->ti_Data);
+				break;
+		}
+		tag++;
+	}
+
+	if (!zz_overlay_source_valid(zz_overlay.src_w, zz_overlay.src_h,
+			zz_overlay.rgbformat))
+		return NULL;
+
+	/* allocate the YUV source bitmap through our own AllocBitMap
+	 * (Displayable+Visible+Clear, the PicassoIV/WinUAE tag set) */
+	{
+		struct TagItem alloc_tags[5];
+		alloc_tags[0].ti_Tag = ABMA_RGBFormat;
+		alloc_tags[0].ti_Data = zz_overlay.rgbformat;
+		alloc_tags[1].ti_Tag = ABMA_Clear;
+		alloc_tags[1].ti_Data = 1;
+		alloc_tags[2].ti_Tag = ABMA_Displayable;
+		alloc_tags[2].ti_Data = 1;
+		alloc_tags[3].ti_Tag = ABMA_Visible;
+		alloc_tags[3].ti_Data = 1;
+		alloc_tags[4].ti_Tag = TAG_DONE;
+		alloc_tags[4].ti_Data = 0;
+
+		zz_overlay_bitmap = ZZ_AllocBitMap(b, zz_overlay.src_w,
+			zz_overlay.src_h, alloc_tags);
+	}
+	if (!zz_overlay_bitmap)
+		return NULL;
+
+	/* enable the firmware master gate (the vblank ISR checks it) */
+	{
+		MNTZZ9KRegs* registers = (MNTZZ9KRegs*)b->RegisterBase;
+		zzwrite16(&registers->blitter_user1, CARD_FEATURE_VIDEO_OVERLAY);
+		zzwrite16(&registers->set_feature_status, 1);
+	}
+
+	zz_overlay.magic = ZZ_OVERLAY_MAGIC;
+
+	if (zz_overlay_push(b, 0) != 0) {
+		zz_overlay.magic = 0;
+		ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
+		zz_overlay_bitmap = NULL;
+		return NULL;
+	}
+
+	return (APTR)&zz_overlay;
+}
+
+static int zz_overlay_cookie_ok(APTR fd) {
+	return fd == (APTR)&zz_overlay && zz_overlay.magic == ZZ_OVERLAY_MAGIC &&
+		zz_overlay_bitmap != NULL;
+}
+
+ULONG ZZ_SetFeatureAttrs(__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0(ULONG type), __REGA2(struct TagItem *tags)) {
+	ULONG count = 0;
+	int dirty = 0;
+
+	if (!b || !zz_overlay_cookie_ok(fd))
+		return 0;
+
+	struct TagItem *tag = tags;
+	int guard = 64;
+	while (tag && tag->ti_Tag != TAG_DONE && guard--) {
+		switch (tag->ti_Tag) {
+			case TAG_IGNORE: break;
+			case TAG_SKIP: tag += tag->ti_Data; break;
+			case TAG_MORE: tag = (struct TagItem *)tag->ti_Data; continue;
+			default:
+#ifdef DEBUG
+				KPrintF("ZZ9000: SetFeatureAttrs tag=%08lx data=%08lx\n",
+					tag->ti_Tag, tag->ti_Data);
+#endif
+				dirty |= zz_overlay_apply_tag(&zz_overlay, tag->ti_Tag,
+					tag->ti_Data);
+				count++;
+				break;
+		}
+		tag++;
+	}
+
+	if (dirty)
+		zz_overlay_push(b, 0);
+
+	return count;
+}
+
+ULONG ZZ_GetFeatureAttrs(__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0(ULONG type), __REGA2(struct TagItem *tags)) {
+	ULONG count = 0;
+	int have = zz_overlay_cookie_ok(fd);
+
+	if (!b)
+		return 0;
+
+	struct TagItem *tag = tags;
+	int guard = 64;
+	while (tag && tag->ti_Tag != TAG_DONE && guard--) {
+		switch (tag->ti_Tag) {
+			case TAG_IGNORE: break;
+			case TAG_SKIP: tag += tag->ti_Data; break;
+			case TAG_MORE: tag = (struct TagItem *)tag->ti_Data; continue;
+			default: {
+				uint32_t out;
+				if (zz_overlay_query_tag(&zz_overlay, have,
+						(uint32_t)zz_overlay_bitmap,
+						tag->ti_Tag, &out)) {
+					/* ti_Data is a pointer to the result slot
+					 * (WinUAE settag semantics) */
+					if (tag->ti_Data)
+						*(ULONG *)tag->ti_Data = out;
+					count++;
+				}
+#ifdef DEBUG
+				KPrintF("ZZ9000: GetFeatureAttrs tag=%08lx data=%08lx\n",
+					tag->ti_Tag, tag->ti_Data);
+#endif
+				break;
+			}
+		}
+		tag++;
+	}
+
+	return count;
+}
+
+BOOL ZZ_DeleteFeature(__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0(ULONG type)) {
+	if (!b || type != SFT_MEMORYWINDOW || !zz_overlay_cookie_ok(fd))
+		return FALSE;
+
+	zz_overlay_push(b, 1);
+	zz_overlay.magic = 0;
+	ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
+	zz_overlay_bitmap = NULL;
+
+	return TRUE;
 }
 
 // This function shall blit a planar bitmap anywhere in the 68K address space into a chunky bitmap in video RAM.

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -156,6 +156,13 @@ struct ExecBase *SysBase;
 static struct ConfigDev *reserved_cd = NULL;
 static struct BlitterRegisterCache blitter_register_cache;
 static BOOL zz_overlay_hooks_enabled = FALSE;
+/* Card memory addressable from MemoryBase (autoconfig window minus the
+ * 64 KB register space). b->MemorySize is SMALLER on Z3: it only caps
+ * P96's own VRAM allocator, while the firmware surface heap for
+ * off-screen bitmaps sits deliberately ABOVE it (board ~0x3310000+),
+ * still inside the autoconfig window. Ownership/on-board checks must
+ * bound Planes[0] against this, never against b->MemorySize. */
+static ULONG zz_card_window_size = 0;
 
 static inline volatile struct GFXData *zz_gfxdata(struct BoardInfo *b) {
 	return (volatile struct GFXData *)b->CardData[ZZ_CARD_DATA_GFXDATA];
@@ -665,6 +672,7 @@ int __attribute__((used)) FindCard(__REGA0(struct BoardInfo* b)) {
 	if (zorro_version>=2) {
 
 		b->MemoryBase = (uint8_t*)(cd->cd_BoardAddr)+0x10000;
+		zz_card_window_size = (ULONG)cd->cd_BoardSize - 0x10000;
 		if (zorro_version == 2) {
 			// Top-of-window carve on Z2 (board offsets, 4 MB window):
 			// VRAM ends 0x3D0000, template scratch (zz_template_addr =
@@ -1893,7 +1901,9 @@ static struct ZZBitMap *zz_bitmap_ours(struct BoardInfo *b, struct BitMap *bm) {
 		return NULL;
 
 	if (!zz_offscreen_is_ours(zbm->magic, (uint32_t)bm->Planes[0],
-			(uint32_t)b->MemoryBase, (uint32_t)b->MemorySize))
+			(uint32_t)b->MemoryBase,
+			zz_card_window_size ? (uint32_t)zz_card_window_size :
+			(uint32_t)b->MemorySize))
 		return NULL;
 
 	return zbm;
@@ -2233,10 +2243,14 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 	}
 
 	/* the compositor reads the source from card VRAM; ZZ_AllocBitMap
-	 * guarantees that, so this is a belt-and-braces diagnostic */
+	 * guarantees that, so this is a belt-and-braces diagnostic. The
+	 * bound is the autoconfig window, NOT b->MemorySize: the firmware
+	 * surface heap sits above the P96 window (see zz_card_window_size),
+	 * which a previous MemorySize-based check here misread as a
+	 * system-RAM placement. */
 	if ((uint32_t)zz_overlay_bitmap->Planes[0] < (uint32_t)b->MemoryBase ||
 	    (uint32_t)zz_overlay_bitmap->Planes[0] - (uint32_t)b->MemoryBase >=
-	    (uint32_t)b->MemorySize) {
+	    (uint32_t)zz_card_window_size) {
 		KPrintF("ZZ9000: CreateFeature source NOT on board (%08lx)\n",
 			(ULONG)zz_overlay_bitmap->Planes[0]);
 		ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
@@ -2273,9 +2287,9 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		}
 	}
 
-	KPrintF("ZZ9000: CreateFeature OK (%ldx%ld fmt %ld)\n",
+	KPrintF("ZZ9000: CreateFeature OK (%ldx%ld fmt %ld src %08lx)\n",
 		(LONG)zz_overlay.src_w, (LONG)zz_overlay.src_h,
-		(LONG)zz_overlay.rgbformat);
+		(LONG)zz_overlay.rgbformat, (ULONG)zz_overlay_bitmap->Planes[0]);
 	return (APTR)&zz_overlay;
 }
 

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -906,6 +906,10 @@ int __attribute__((used)) InitCard(__REGA0(struct BoardInfo* b), __REGA1(char **
 		if (pip && fwrev >= VIDEO_OVERLAY_MIN_FWREV &&
 				(b->CardFlags & CARDFLAG_ZORRO_3) && b->AllocBitMap) {
 			b->Flags |= BIF_VIDEOWINDOW;
+			/* required for ON-BOARD placement of the PIP source:
+			 * p96AllocBitMap only considers card VRAM for a
+			 * displayable bitmap whose format bit is advertised */
+			b->RGBFormats |= (UWORD)ZZ_OVERLAY_BOARD_FORMATS;
 			b->GetFeatureAttrs = (void *)ZZ_GetFeatureAttrs;
 			b->CreateFeature = (void *)ZZ_CreateFeature;
 			b->SetFeatureAttrs = (void *)ZZ_SetFeatureAttrs;

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -2125,6 +2125,10 @@ int ZZ_WriteYUVRect(__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHO
 
 static struct ZZOverlayState zz_overlay;
 static struct BitMap *zz_overlay_bitmap = NULL;
+/* RastPort handed to the app for P96PIP_SourceRPort: wraps the source
+ * bitmap; equivalent of InitRastPort defaults, built by hand so the
+ * driver needs no graphics.library base */
+static struct RastPort zz_overlay_rport;
 
 /* Push the full overlay state (or OFF) to the firmware; returns the
  * firmware status word (0 = OK). */
@@ -2224,6 +2228,14 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		zzwrite16(&registers->set_feature_status, 1);
 	}
 
+	memset(&zz_overlay_rport, 0, sizeof(zz_overlay_rport));
+	zz_overlay_rport.BitMap = zz_overlay_bitmap;
+	zz_overlay_rport.Mask = 0xFF;
+	zz_overlay_rport.FgPen = -1;
+	zz_overlay_rport.AOlPen = -1;
+	zz_overlay_rport.LinePtrn = 0xFFFF;
+	zz_overlay_rport.DrawMode = 1; /* JAM2 */
+
 	zz_overlay.magic = ZZ_OVERLAY_MAGIC;
 
 	{
@@ -2302,6 +2314,29 @@ ULONG ZZ_GetFeatureAttrs(__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0
 			case TAG_MORE: tag = (struct TagItem *)tag->ti_Data; continue;
 			default: {
 				uint32_t out;
+				/* the app's p96PIP_GetTags queries arrive here:
+				 * unanswered source-object queries crash the app
+				 * on an undefined pointer */
+				if (have && tag->ti_Tag == ZZ_P96PIP_SOURCEBITMAP) {
+					if (tag->ti_Data)
+						*(ULONG *)tag->ti_Data = (ULONG)zz_overlay_bitmap;
+					count++;
+#ifdef DEBUG
+					KPrintF("ZZ9000: GetFeatureAttrs PIP bitmap -> %08lx\n",
+						(ULONG)zz_overlay_bitmap);
+#endif
+					break;
+				}
+				if (have && tag->ti_Tag == ZZ_P96PIP_SOURCERPORT) {
+					if (tag->ti_Data)
+						*(ULONG *)tag->ti_Data = (ULONG)&zz_overlay_rport;
+					count++;
+#ifdef DEBUG
+					KPrintF("ZZ9000: GetFeatureAttrs PIP rport -> %08lx\n",
+						(ULONG)&zz_overlay_rport);
+#endif
+					break;
+				}
 				if (zz_overlay_query_tag(&zz_overlay, have,
 						(uint32_t)zz_overlay_bitmap,
 						tag->ti_Tag, &out)) {

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -2187,8 +2187,12 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 	}
 
 	if (!zz_overlay_source_valid(zz_overlay.src_w, zz_overlay.src_h,
-			zz_overlay.rgbformat))
+			zz_overlay.rgbformat)) {
+		KPrintF("ZZ9000: CreateFeature REJECT src %ldx%ld fmt %ld\n",
+			(LONG)zz_overlay.src_w, (LONG)zz_overlay.src_h,
+			(LONG)zz_overlay.rgbformat);
 		return NULL;
+	}
 
 	/* allocate the YUV source bitmap through our own AllocBitMap
 	 * (Displayable+Visible+Clear, the PicassoIV/WinUAE tag set) */
@@ -2208,8 +2212,10 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		zz_overlay_bitmap = ZZ_AllocBitMap(b, zz_overlay.src_w,
 			zz_overlay.src_h, alloc_tags);
 	}
-	if (!zz_overlay_bitmap)
+	if (!zz_overlay_bitmap) {
+		KPrintF("ZZ9000: CreateFeature AllocBitMap FAILED\n");
 		return NULL;
+	}
 
 	/* enable the firmware master gate (the vblank ISR checks it) */
 	{
@@ -2220,13 +2226,21 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 
 	zz_overlay.magic = ZZ_OVERLAY_MAGIC;
 
-	if (zz_overlay_push(b, 0) != 0) {
-		zz_overlay.magic = 0;
-		ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
-		zz_overlay_bitmap = NULL;
-		return NULL;
+	{
+		ULONG fw_status = zz_overlay_push(b, 0);
+		if (fw_status != 0) {
+			KPrintF("ZZ9000: CreateFeature fw SET status %ld\n",
+				(LONG)fw_status);
+			zz_overlay.magic = 0;
+			ZZ_FreeBitMap(b, zz_overlay_bitmap, NULL);
+			zz_overlay_bitmap = NULL;
+			return NULL;
+		}
 	}
 
+	KPrintF("ZZ9000: CreateFeature OK (%ldx%ld fmt %ld)\n",
+		(LONG)zz_overlay.src_w, (LONG)zz_overlay.src_h,
+		(LONG)zz_overlay.rgbformat);
 	return (APTR)&zz_overlay;
 }
 

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -2219,9 +2219,35 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 		return NULL;
 	}
 
-	zz_overlay_bitmap = p96AllocBitMap(zz_overlay.src_w, zz_overlay.src_h,
-		16, BMF_CLEAR | BMF_DISPLAYABLE, NULL,
-		(RGBFTYPE)zz_overlay.rgbformat);
+	/* On-board placement needs BOARD AFFINITY: a friend bitmap that
+	 * lives in card VRAM (the same mechanism that routes off-screen
+	 * bitmaps through our AllocBitMap hook - friend-compatibility runs
+	 * through GetCompatibleFormats, where the YUV formats are OR'd in
+	 * while the hooks are enabled). BMF_DISPLAYABLE would do the
+	 * opposite: no display mode exists for YUV, so a displayable
+	 * request lands in system RAM. The PIP window sits on the default
+	 * public screen, whose bitmap is the natural friend. */
+	{
+		struct IntuitionBase *IntuitionBase =
+			(struct IntuitionBase *)OpenLibrary((APTR)"intuition.library", 36);
+		struct Screen *scr = NULL;
+		struct BitMap *friend_bm = NULL;
+
+		if (IntuitionBase) {
+			scr = LockPubScreen(NULL);
+			if (scr)
+				friend_bm = scr->RastPort.BitMap;
+		}
+
+		zz_overlay_bitmap = p96AllocBitMap(zz_overlay.src_w,
+			zz_overlay.src_h, 16, BMF_CLEAR, friend_bm,
+			(RGBFTYPE)zz_overlay.rgbformat);
+
+		if (scr)
+			UnlockPubScreen(NULL, scr);
+		if (IntuitionBase)
+			CloseLibrary((struct Library *)IntuitionBase);
+	}
 	if (!zz_overlay_bitmap) {
 		KPrintF("ZZ9000: CreateFeature p96AllocBitMap FAILED\n");
 		return NULL;

--- a/rtg/mntgfx-gcc.h
+++ b/rtg/mntgfx-gcc.h
@@ -80,6 +80,7 @@ void BlitPlanar2Direct (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bmp
 struct BitMap * ZZ_AllocBitMap (__REGA0(struct BoardInfo *b), __REGD0(ULONG width), __REGD1(ULONG height), __REGA1(struct TagItem *tags));
 BOOL ZZ_FreeBitMap (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGA2(struct TagItem *tags));
 ULONG ZZ_GetBitMapAttr (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGD0(ULONG attr));
+int ZZ_WriteYUVRect (__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHORT srcx), __REGD1(SHORT srcy), __REGA2(struct RenderInfo *r), __REGD2(SHORT dstx), __REGD3(SHORT dsty), __REGD4(SHORT w), __REGD5(SHORT h), __REGA3(struct TagItem *tags));
 
 BOOL SetSprite (__REGA0(struct BoardInfo *b), __REGD0(BOOL what), __REGD7(RGBFTYPE format));
 void SetSpritePosition (__REGA0(struct BoardInfo *b), __REGD0(WORD x), __REGD1(WORD y), __REGD7(RGBFTYPE format));

--- a/rtg/mntgfx-gcc.h
+++ b/rtg/mntgfx-gcc.h
@@ -81,6 +81,10 @@ struct BitMap * ZZ_AllocBitMap (__REGA0(struct BoardInfo *b), __REGD0(ULONG widt
 BOOL ZZ_FreeBitMap (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGA2(struct TagItem *tags));
 ULONG ZZ_GetBitMapAttr (__REGA0(struct BoardInfo *b), __REGA1(struct BitMap *bm), __REGD0(ULONG attr));
 int ZZ_WriteYUVRect (__REGA0(struct BoardInfo *b), __REGA1(APTR src), __REGD0(SHORT srcx), __REGD1(SHORT srcy), __REGA2(struct RenderInfo *r), __REGD2(SHORT dstx), __REGD3(SHORT dsty), __REGD4(SHORT w), __REGD5(SHORT h), __REGA3(struct TagItem *tags));
+APTR ZZ_CreateFeature (__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1(struct TagItem *tags));
+ULONG ZZ_SetFeatureAttrs (__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0(ULONG type), __REGA2(struct TagItem *tags));
+ULONG ZZ_GetFeatureAttrs (__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0(ULONG type), __REGA2(struct TagItem *tags));
+BOOL ZZ_DeleteFeature (__REGA0(struct BoardInfo *b), __REGA1(APTR fd), __REGD0(ULONG type));
 
 BOOL SetSprite (__REGA0(struct BoardInfo *b), __REGD0(BOOL what), __REGD7(RGBFTYPE format));
 void SetSpritePosition (__REGA0(struct BoardInfo *b), __REGD0(WORD x), __REGD1(WORD y), __REGD7(RGBFTYPE format));

--- a/rtg/offscreen_bitmap.h
+++ b/rtg/offscreen_bitmap.h
@@ -56,9 +56,11 @@ static inline uint32_t zz_offscreen_pad_pitch(uint32_t bytesperrow)
 #define ZZ_GBMA_HEIGHT        0x80000008u
 #define ZZ_GBMA_DEPTH         0x80000009u
 
-/* Bytes per pixel for the RGBFB formats the card advertises
- * (ZZ_SUPPORTED_RGB_FORMATS); 0 for planar and everything else, which
- * makes AllocBitMap refuse and P96 fall back to system RAM. */
+/* Bytes per pixel for the RGBFB formats AllocBitMap accepts: the
+ * chunky formats the card advertises (ZZ_SUPPORTED_RGB_FORMATS) plus
+ * the packed 4:2:2 YUV formats used as video-overlay (PIP) sources.
+ * 0 for planar and everything else, which makes AllocBitMap refuse
+ * and P96 fall back to system RAM. */
 static inline uint32_t zz_rgbformat_bytes_per_pixel(uint32_t rgbformat)
 {
 	switch (rgbformat) {
@@ -66,9 +68,21 @@ static inline uint32_t zz_rgbformat_bytes_per_pixel(uint32_t rgbformat)
 		case 9:  return 4; /* RGBFB_B8G8R8A8 */
 		case 10: return 2; /* RGBFB_R5G6B5 */
 		case 11: return 2; /* RGBFB_R5G5B5 */
+		case 14: return 2; /* RGBFB_YUV422CGX (YUY2) */
+		case 17: return 2; /* RGBFB_YUV422 */
+		case 18: return 2; /* RGBFB_YUV422PC (UYVY) */
 	}
 
 	return 0;
+}
+
+/* Bytes per row for the offscreen/overlay allocation path only: the
+ * P96-facing CalculateBytesPerRow stays YUV-blind (it sizes display
+ * modes). Identical to width * bytes-per-pixel for every format. */
+static inline uint32_t zz_offscreen_bytes_per_row(uint32_t rgbformat,
+	uint32_t width)
+{
+	return width * zz_rgbformat_bytes_per_pixel(rgbformat);
 }
 
 /* Format color depth, the P96 ModeInfo convention: RGB555 is a
@@ -81,6 +95,9 @@ static inline uint32_t zz_rgbformat_depth(uint32_t rgbformat)
 		case 9:  return 32;
 		case 10: return 16;
 		case 11: return 15;
+		case 14: /* the packed YUV formats occupy 16 bits per pixel */
+		case 17:
+		case 18: return 16;
 	}
 
 	return 0;

--- a/rtg/overlay_feature.h
+++ b/rtg/overlay_feature.h
@@ -36,6 +36,14 @@
 #define ZZ_FA_CLIPWIDTH     0x80000023u
 #define ZZ_FA_CLIPHEIGHT    0x80000024u
 
+/* P96PIP_* tags P96 forwards to GetFeatureAttrs (TAG_USER + 0x30000 +
+ * 96 + n). Captured logs show the app's p96PIP_GetTags(SourceRPort)
+ * reaching the driver - an unanswered query hands the app an
+ * undefined pointer and crashes the Amiga, so the driver must supply
+ * the source objects. */
+#define ZZ_P96PIP_SOURCEBITMAP 0x80030062u
+#define ZZ_P96PIP_SOURCERPORT  0x80030063u
+
 /* WinUAE's answers for the size limits P96 queries. */
 #define ZZ_OVERLAY_MIN_DIM 16u
 #define ZZ_OVERLAY_MAX_DIM 4096u

--- a/rtg/overlay_feature.h
+++ b/rtg/overlay_feature.h
@@ -30,6 +30,7 @@
 #define ZZ_FA_MAXHEIGHT     0x8000000Fu
 #define ZZ_FA_BITMAP        0x80000012u
 #define ZZ_FA_BRIGHTNESS    0x80000013u
+#define ZZ_FA_PEN           0x8000001Fu
 #define ZZ_FA_CLIPLEFT      0x80000021u
 #define ZZ_FA_CLIPTOP       0x80000022u
 #define ZZ_FA_CLIPWIDTH     0x80000023u
@@ -101,6 +102,10 @@ static inline int zz_overlay_apply_tag(struct ZZOverlayState *st,
 		case ZZ_FA_HEIGHT:      st->dst_h = (int16_t)(int32_t)data; return 1;
 		case ZZ_FA_OCCLUSION:   st->occlusion = data ? 1 : 0; return 1;
 		case ZZ_FA_COLOR:       st->color_key = data; return 1;
+		/* boardinfo.h documents FA_Pen as the RGB-mode key pen; treat
+		 * it as a key alias (WinUAE ignores it - the DEBUG tag logs
+		 * show which one real P96 sends) */
+		case ZZ_FA_PEN:         st->color_key = data; return 1;
 		case ZZ_FA_FORMAT:      st->rgbformat = data; return 1;
 		case ZZ_FA_SOURCEWIDTH: st->src_w = (uint16_t)data; return 1;
 		case ZZ_FA_SOURCEHEIGHT: st->src_h = (uint16_t)data; return 1;
@@ -112,6 +117,15 @@ static inline int zz_overlay_apply_tag(struct ZZOverlayState *st,
 	}
 
 	return 0;
+}
+
+/* Tags that describe the source bitmap: only valid at CreateFeature.
+ * Applying them to a live feature would let the firmware composite
+ * beyond the allocated source surface, so SetFeatureAttrs skips them. */
+static inline int zz_overlay_tag_create_only(uint32_t tag)
+{
+	return tag == ZZ_FA_FORMAT || tag == ZZ_FA_SOURCEWIDTH ||
+		tag == ZZ_FA_SOURCEHEIGHT;
 }
 
 /* GetFeatureAttrs answer for one queried tag; returns 1 if answered.
@@ -140,7 +154,8 @@ static inline int zz_overlay_query_tag(const struct ZZOverlayState *st,
 		case ZZ_FA_SOURCEWIDTH:  *out = st->src_w; return 1;
 		case ZZ_FA_SOURCEHEIGHT: *out = st->src_h; return 1;
 		case ZZ_FA_FORMAT:       *out = st->rgbformat; return 1;
-		case ZZ_FA_COLOR:        *out = st->color_key; return 1;
+		case ZZ_FA_COLOR:
+		case ZZ_FA_PEN:          *out = st->color_key; return 1;
 		case ZZ_FA_BITMAP:       *out = bitmap; return 1;
 		case ZZ_FA_BRIGHTNESS:   *out = st->brightness; return 1;
 		case ZZ_FA_CLIPLEFT:     *out = (uint32_t)(int32_t)st->clip_l; return 1;

--- a/rtg/overlay_feature.h
+++ b/rtg/overlay_feature.h
@@ -1,0 +1,155 @@
+/*
+ * Pure helpers for the P96 video window (PIP) Features API.
+ *
+ * No Amiga headers so the logic is host-testable; the driver keeps the
+ * feature record and the register/tag plumbing in mntgfx-gcc.c and
+ * passes plain integers in here. The contract is modeled on WinUAE's
+ * uaegfx overlay implementation (picasso96_win.cpp), the only public
+ * reference for how P96 drives these hooks.
+ */
+
+#ifndef ZZ9000_OVERLAY_FEATURE_H
+#define ZZ9000_OVERLAY_FEATURE_H
+
+#include <stdint.h>
+
+/* Feature-attribute tags (mirror boardinfo.h: TAG_USER + n). */
+#define ZZ_FA_ACTIVE        0x80000002u
+#define ZZ_FA_LEFT          0x80000003u
+#define ZZ_FA_TOP           0x80000004u
+#define ZZ_FA_WIDTH         0x80000005u
+#define ZZ_FA_HEIGHT        0x80000006u
+#define ZZ_FA_FORMAT        0x80000007u
+#define ZZ_FA_COLOR         0x80000008u
+#define ZZ_FA_OCCLUSION     0x80000009u
+#define ZZ_FA_SOURCEWIDTH   0x8000000Au
+#define ZZ_FA_SOURCEHEIGHT  0x8000000Bu
+#define ZZ_FA_MINWIDTH      0x8000000Cu
+#define ZZ_FA_MINHEIGHT     0x8000000Du
+#define ZZ_FA_MAXWIDTH      0x8000000Eu
+#define ZZ_FA_MAXHEIGHT     0x8000000Fu
+#define ZZ_FA_BITMAP        0x80000012u
+#define ZZ_FA_BRIGHTNESS    0x80000013u
+#define ZZ_FA_CLIPLEFT      0x80000021u
+#define ZZ_FA_CLIPTOP       0x80000022u
+#define ZZ_FA_CLIPWIDTH     0x80000023u
+#define ZZ_FA_CLIPHEIGHT    0x80000024u
+
+/* WinUAE's answers for the size limits P96 queries. */
+#define ZZ_OVERLAY_MIN_DIM 16u
+#define ZZ_OVERLAY_MAX_DIM 4096u
+
+/* Overlay source formats accepted initially: the unambiguous packed
+ * 4:2:2 orderings (RGBFB bit space, as in supported_rgb_format). The
+ * PA/PAPC variants are kernel-ready but stay unadvertised until
+ * hardware-validated. */
+#define ZZ_OVERLAY_SOURCE_FORMATS \
+	((1UL << 14) | (1UL << 17) | (1UL << 18))
+
+/* RGBFB YUV format -> firmware yuv422_variant, -1 if unsupported. */
+static inline int zz_overlay_variant(uint32_t rgbformat)
+{
+	switch (rgbformat) {
+		case 14: return 0; /* YUV422CGX -> YUV422_VARIANT_CGX */
+		case 17: return 1; /* YUV422    -> YUV422_VARIANT_STD */
+		case 18: return 2; /* YUV422PC  -> YUV422_VARIANT_PC */
+	}
+
+	return -1;
+}
+
+/* CreateFeature source validation (WinUAE parity: >=16x16, <=4096,
+ * supported format). The <=screen check is left to the firmware, which
+ * clips at composite time anyway. */
+static inline int zz_overlay_source_valid(uint32_t src_w, uint32_t src_h,
+	uint32_t rgbformat)
+{
+	return src_w >= ZZ_OVERLAY_MIN_DIM && src_h >= ZZ_OVERLAY_MIN_DIM &&
+		src_w <= ZZ_OVERLAY_MAX_DIM && src_h <= ZZ_OVERLAY_MAX_DIM &&
+		zz_overlay_variant(rgbformat) >= 0;
+}
+
+/* The driver-side feature record; a pointer to it is the opaque cookie
+ * handed to P96. */
+struct ZZOverlayState {
+	uint32_t magic;         /* cookie validation */
+	uint32_t rgbformat;
+	uint16_t src_w, src_h;
+	int16_t dst_x, dst_y;
+	int16_t dst_w, dst_h;
+	uint32_t color_key;     /* as P96 gave it (FA_Color) */
+	uint8_t occlusion;
+	uint8_t active;
+	/* stored but deliberately not applied (WinUAE parity) */
+	int16_t clip_l, clip_t, clip_w, clip_h;
+	uint32_t brightness;
+};
+
+#define ZZ_OVERLAY_MAGIC 0x5A5A4F56u /* 'ZZOV' */
+
+/* Apply one SetFeatureAttrs/CreateFeature tag to the record. Returns 1
+ * if the tag changed state the firmware must see (geometry/key/active),
+ * 0 if it was stored-only or ignored. */
+static inline int zz_overlay_apply_tag(struct ZZOverlayState *st,
+	uint32_t tag, uint32_t data)
+{
+	switch (tag) {
+		case ZZ_FA_ACTIVE:      st->active = data ? 1 : 0; return 1;
+		case ZZ_FA_LEFT:        st->dst_x = (int16_t)(int32_t)data; return 1;
+		case ZZ_FA_TOP:         st->dst_y = (int16_t)(int32_t)data; return 1;
+		case ZZ_FA_WIDTH:       st->dst_w = (int16_t)(int32_t)data; return 1;
+		case ZZ_FA_HEIGHT:      st->dst_h = (int16_t)(int32_t)data; return 1;
+		case ZZ_FA_OCCLUSION:   st->occlusion = data ? 1 : 0; return 1;
+		case ZZ_FA_COLOR:       st->color_key = data; return 1;
+		case ZZ_FA_FORMAT:      st->rgbformat = data; return 1;
+		case ZZ_FA_SOURCEWIDTH: st->src_w = (uint16_t)data; return 1;
+		case ZZ_FA_SOURCEHEIGHT: st->src_h = (uint16_t)data; return 1;
+		case ZZ_FA_CLIPLEFT:    st->clip_l = (int16_t)(int32_t)data; return 0;
+		case ZZ_FA_CLIPTOP:     st->clip_t = (int16_t)(int32_t)data; return 0;
+		case ZZ_FA_CLIPWIDTH:   st->clip_w = (int16_t)(int32_t)data; return 0;
+		case ZZ_FA_CLIPHEIGHT:  st->clip_h = (int16_t)(int32_t)data; return 0;
+		case ZZ_FA_BRIGHTNESS:  st->brightness = data; return 0;
+	}
+
+	return 0;
+}
+
+/* GetFeatureAttrs answer for one queried tag; returns 1 if answered.
+ * `bitmap` is the source BitMap pointer, `have` whether a feature
+ * exists. */
+static inline int zz_overlay_query_tag(const struct ZZOverlayState *st,
+	int have, uint32_t bitmap, uint32_t tag, uint32_t *out)
+{
+	switch (tag) {
+		case ZZ_FA_MINWIDTH:
+		case ZZ_FA_MINHEIGHT:  *out = ZZ_OVERLAY_MIN_DIM; return 1;
+		case ZZ_FA_MAXWIDTH:
+		case ZZ_FA_MAXHEIGHT:  *out = ZZ_OVERLAY_MAX_DIM; return 1;
+	}
+
+	if (!have)
+		return 0;
+
+	switch (tag) {
+		case ZZ_FA_ACTIVE:       *out = st->active; return 1;
+		case ZZ_FA_OCCLUSION:    *out = st->occlusion; return 1;
+		case ZZ_FA_LEFT:         *out = (uint32_t)(int32_t)st->dst_x; return 1;
+		case ZZ_FA_TOP:          *out = (uint32_t)(int32_t)st->dst_y; return 1;
+		case ZZ_FA_WIDTH:        *out = (uint32_t)(int32_t)st->dst_w; return 1;
+		case ZZ_FA_HEIGHT:       *out = (uint32_t)(int32_t)st->dst_h; return 1;
+		case ZZ_FA_SOURCEWIDTH:  *out = st->src_w; return 1;
+		case ZZ_FA_SOURCEHEIGHT: *out = st->src_h; return 1;
+		case ZZ_FA_FORMAT:       *out = st->rgbformat; return 1;
+		case ZZ_FA_COLOR:        *out = st->color_key; return 1;
+		case ZZ_FA_BITMAP:       *out = bitmap; return 1;
+		case ZZ_FA_BRIGHTNESS:   *out = st->brightness; return 1;
+		case ZZ_FA_CLIPLEFT:     *out = (uint32_t)(int32_t)st->clip_l; return 1;
+		case ZZ_FA_CLIPTOP:      *out = (uint32_t)(int32_t)st->clip_t; return 1;
+		case ZZ_FA_CLIPWIDTH:    *out = (uint32_t)(int32_t)st->clip_w; return 1;
+		case ZZ_FA_CLIPHEIGHT:   *out = (uint32_t)(int32_t)st->clip_h; return 1;
+	}
+
+	return 0;
+}
+
+#endif

--- a/rtg/overlay_feature.h
+++ b/rtg/overlay_feature.h
@@ -79,6 +79,10 @@ struct ZZOverlayState {
 	int16_t dst_x, dst_y;
 	int16_t dst_w, dst_h;
 	uint32_t color_key;     /* as P96 gave it (FA_Color) */
+	uint32_t pen;           /* FA_Pen: the key's PEN INDEX - captured
+	                         * logs show P96 sends FA_Color (the value)
+	                         * and then FA_Pen (the index); the index
+	                         * must not clobber the truecolor key */
 	uint8_t occlusion;
 	uint8_t active;
 	/* stored but deliberately not applied (WinUAE parity) */
@@ -102,10 +106,10 @@ static inline int zz_overlay_apply_tag(struct ZZOverlayState *st,
 		case ZZ_FA_HEIGHT:      st->dst_h = (int16_t)(int32_t)data; return 1;
 		case ZZ_FA_OCCLUSION:   st->occlusion = data ? 1 : 0; return 1;
 		case ZZ_FA_COLOR:       st->color_key = data; return 1;
-		/* boardinfo.h documents FA_Pen as the RGB-mode key pen; treat
-		 * it as a key alias (WinUAE ignores it - the DEBUG tag logs
-		 * show which one real P96 sends) */
-		case ZZ_FA_PEN:         st->color_key = data; return 1;
+		/* FA_Pen carries the key's pen INDEX (captured P96 logs show
+		 * it sent after FA_Color): stored for echo only - using it as
+		 * the key would break every truecolor screen */
+		case ZZ_FA_PEN:         st->pen = data; return 0;
 		case ZZ_FA_FORMAT:      st->rgbformat = data; return 1;
 		case ZZ_FA_SOURCEWIDTH: st->src_w = (uint16_t)data; return 1;
 		case ZZ_FA_SOURCEHEIGHT: st->src_h = (uint16_t)data; return 1;
@@ -154,8 +158,8 @@ static inline int zz_overlay_query_tag(const struct ZZOverlayState *st,
 		case ZZ_FA_SOURCEWIDTH:  *out = st->src_w; return 1;
 		case ZZ_FA_SOURCEHEIGHT: *out = st->src_h; return 1;
 		case ZZ_FA_FORMAT:       *out = st->rgbformat; return 1;
-		case ZZ_FA_COLOR:
-		case ZZ_FA_PEN:          *out = st->color_key; return 1;
+		case ZZ_FA_COLOR:        *out = st->color_key; return 1;
+		case ZZ_FA_PEN:          *out = st->pen; return 1;
 		case ZZ_FA_BITMAP:       *out = bitmap; return 1;
 		case ZZ_FA_BRIGHTNESS:   *out = st->brightness; return 1;
 		case ZZ_FA_CLIPLEFT:     *out = (uint32_t)(int32_t)st->clip_l; return 1;

--- a/rtg/overlay_feature.h
+++ b/rtg/overlay_feature.h
@@ -55,6 +55,14 @@
 #define ZZ_OVERLAY_SOURCE_FORMATS \
 	((1UL << 14) | (1UL << 17) | (1UL << 18))
 
+/* The subset advertised in BoardInfo->RGBFormats (a UWORD, so only
+ * formats 0-15 fit): P96 only places a DISPLAYABLE bitmap on the board
+ * when its format bit is set here, and p96AllocBitMap must land the
+ * PIP source in VRAM or the feature open fails to the software path.
+ * YUV422CGX (14) is what P96's cgxvideo emulation requests; the mode
+ * database has no YUV entries, so no YUV screen modes can appear. */
+#define ZZ_OVERLAY_BOARD_FORMATS ((1UL << 14))
+
 /* RGBFB YUV format -> firmware yuv422_variant, -1 if unsupported. */
 static inline int zz_overlay_variant(uint32_t rgbformat)
 {

--- a/rtg/overlay_feature.h
+++ b/rtg/overlay_feature.h
@@ -55,14 +55,6 @@
 #define ZZ_OVERLAY_SOURCE_FORMATS \
 	((1UL << 14) | (1UL << 17) | (1UL << 18))
 
-/* The subset advertised in BoardInfo->RGBFormats (a UWORD, so only
- * formats 0-15 fit): P96 only places a DISPLAYABLE bitmap on the board
- * when its format bit is set here, and p96AllocBitMap must land the
- * PIP source in VRAM or the feature open fails to the software path.
- * YUV422CGX (14) is what P96's cgxvideo emulation requests; the mode
- * database has no YUV entries, so no YUV screen modes can appear. */
-#define ZZ_OVERLAY_BOARD_FORMATS ((1UL << 14))
-
 /* RGBFB YUV format -> firmware yuv422_variant, -1 if unsupported. */
 static inline int zz_overlay_variant(uint32_t rgbformat)
 {

--- a/rtg/tests/Makefile
+++ b/rtg/tests/Makefile
@@ -2,7 +2,7 @@ CC ?= cc
 CFLAGS ?= -O2 -g
 
 TARGET := build/register_cache_test
-TARGETS := $(TARGET) build/p96_settings_test build/offscreen_bitmap_test
+TARGETS := $(TARGET) build/p96_settings_test build/offscreen_bitmap_test build/overlay_feature_test
 
 .PHONY: test clean
 
@@ -10,6 +10,7 @@ test: $(TARGETS)
 	$(TARGET)
 	build/p96_settings_test
 	build/offscreen_bitmap_test
+	build/overlay_feature_test
 
 $(TARGET): register_cache_test.c ../blitter_cache.h
 	@mkdir -p build
@@ -22,6 +23,10 @@ build/p96_settings_test: p96_settings_test.c
 build/offscreen_bitmap_test: offscreen_bitmap_test.c ../offscreen_bitmap.h
 	@mkdir -p build
 	$(CC) -Wall -Wextra $(CFLAGS) -I.. -o $@ offscreen_bitmap_test.c
+
+build/overlay_feature_test: overlay_feature_test.c ../overlay_feature.h
+	@mkdir -p build
+	$(CC) -Wall -Wextra $(CFLAGS) -I.. -o $@ overlay_feature_test.c
 
 clean:
 	rm -rf build

--- a/rtg/tests/offscreen_bitmap_test.c
+++ b/rtg/tests/offscreen_bitmap_test.c
@@ -39,8 +39,24 @@ static void test_format_tables(void)
 	CHECK(zz_rgbformat_bytes_per_pixel(0) == 0);   /* RGBFB_NONE/planar */
 	CHECK(zz_rgbformat_bytes_per_pixel(2) == 0);   /* 24BPP RGB */
 	CHECK(zz_rgbformat_bytes_per_pixel(6) == 0);   /* 32BPP ARGB */
-	CHECK(zz_rgbformat_bytes_per_pixel(14) == 0);  /* YUV 4:2:2 */
 	CHECK(zz_rgbformat_bytes_per_pixel(21) == 0);
+
+	/* packed 4:2:2 YUV: allocatable as PIP overlay sources */
+	CHECK(zz_rgbformat_bytes_per_pixel(14) == 2);  /* YUV422CGX */
+	CHECK(zz_rgbformat_bytes_per_pixel(17) == 2);  /* YUV422 */
+	CHECK(zz_rgbformat_bytes_per_pixel(18) == 2);  /* YUV422PC */
+	CHECK(zz_rgbformat_bytes_per_pixel(15) == 0);  /* ACCUPAK stays out */
+	CHECK(zz_rgbformat_depth(14) == 16);
+	CHECK(zz_rgbformat_depth(17) == 16);
+	CHECK(zz_rgbformat_depth(18) == 16);
+
+	/* offscreen pitch equals width * bpp for every accepted format */
+	CHECK(zz_offscreen_bytes_per_row(1, 640) == 640);
+	CHECK(zz_offscreen_bytes_per_row(9, 640) == 2560);
+	CHECK(zz_offscreen_bytes_per_row(10, 640) == 1280);
+	CHECK(zz_offscreen_bytes_per_row(11, 640) == 1280);
+	CHECK(zz_offscreen_bytes_per_row(14, 640) == 1280);
+	CHECK(zz_offscreen_bytes_per_row(0, 640) == 0);
 	CHECK(zz_rgbformat_bytes_per_pixel(0xffffffffu) == 0);
 	CHECK(zz_rgbformat_depth(0) == 0);
 	CHECK(zz_rgbformat_depth(6) == 0);

--- a/rtg/tests/overlay_feature_test.c
+++ b/rtg/tests/overlay_feature_test.c
@@ -99,9 +99,12 @@ static void test_apply_tags(void)
 	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_BRIGHTNESS, 0x1234) == 0);
 	CHECK(st.brightness == 0x1234);
 
-	/* FA_Pen is a key alias (boardinfo.h: the RGB-mode key pen) */
-	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_PEN, 0x00FF00FF) == 1);
-	CHECK(st.color_key == 0x00FF00FF);
+	/* FA_Pen is the key's pen index: stored, but never clobbers the
+	 * truecolor key (P96 sends FA_Color first, then FA_Pen) */
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_COLOR, 0x11001100) == 1);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_PEN, 0x2B) == 0);
+	CHECK(st.color_key == 0x11001100);
+	CHECK(st.pen == 0x2B);
 
 	/* unknown tags: ignored, not dirty */
 	CHECK(zz_overlay_apply_tag(&st, 0x80000030u, 7) == 0);
@@ -136,6 +139,7 @@ static void test_query_tags(void)
 	st.src_h = 360;
 	st.rgbformat = 14;
 	st.color_key = 0xAA55AA55;
+	st.pen = 0x2B;
 	st.occlusion = 1;
 	st.brightness = 9;
 	st.clip_l = 1;
@@ -153,7 +157,7 @@ static void test_query_tags(void)
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_SOURCEWIDTH, &out) && out == 640);
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_FORMAT, &out) && out == 14);
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_COLOR, &out) && out == 0xAA55AA55);
-	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_PEN, &out) && out == 0xAA55AA55);
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_PEN, &out) && out == 0x2B);
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_BITMAP, &out) && out == 0x40001234);
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_BRIGHTNESS, &out) && out == 9);
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_CLIPLEFT, &out) && out == 1);

--- a/rtg/tests/overlay_feature_test.c
+++ b/rtg/tests/overlay_feature_test.c
@@ -1,0 +1,162 @@
+/*
+ * Host tests for the P96 video window (PIP) feature helpers
+ * (overlay_feature.h).
+ *
+ * Build/run: make -C rtg/tests test (or `make rtg-tests` from the root).
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include "overlay_feature.h"
+
+static int failures = 0;
+static int checks = 0;
+
+#define CHECK(cond) do { \
+	checks++; \
+	if (!(cond)) { \
+		failures++; \
+		printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+	} \
+} while (0)
+
+static void test_variant_map(void)
+{
+	CHECK(zz_overlay_variant(14) == 0); /* CGX  -> YUV422_VARIANT_CGX */
+	CHECK(zz_overlay_variant(17) == 1); /* 422  -> YUV422_VARIANT_STD */
+	CHECK(zz_overlay_variant(18) == 2); /* PC   -> YUV422_VARIANT_PC */
+
+	/* not accepted: RGB/CLUT, ACCUPAK, PA/PAPC (unadvertised), junk */
+	CHECK(zz_overlay_variant(0) < 0);
+	CHECK(zz_overlay_variant(1) < 0);
+	CHECK(zz_overlay_variant(9) < 0);
+	CHECK(zz_overlay_variant(15) < 0);
+	CHECK(zz_overlay_variant(16) < 0);
+	CHECK(zz_overlay_variant(19) < 0);
+	CHECK(zz_overlay_variant(20) < 0);
+	CHECK(zz_overlay_variant(0xffffffffu) < 0);
+}
+
+static void test_format_mask(void)
+{
+	CHECK(ZZ_OVERLAY_SOURCE_FORMATS & (1UL << 14));
+	CHECK(ZZ_OVERLAY_SOURCE_FORMATS & (1UL << 17));
+	CHECK(ZZ_OVERLAY_SOURCE_FORMATS & (1UL << 18));
+	CHECK(!(ZZ_OVERLAY_SOURCE_FORMATS & (1UL << 19)));
+	CHECK(!(ZZ_OVERLAY_SOURCE_FORMATS & (1UL << 15)));
+	CHECK(!(ZZ_OVERLAY_SOURCE_FORMATS & (1UL << 9)));
+}
+
+static void test_source_validation(void)
+{
+	CHECK(zz_overlay_source_valid(16, 16, 14));
+	CHECK(zz_overlay_source_valid(320, 240, 17));
+	CHECK(zz_overlay_source_valid(4096, 4096, 18));
+
+	CHECK(!zz_overlay_source_valid(15, 240, 14));   /* too narrow */
+	CHECK(!zz_overlay_source_valid(320, 15, 14));   /* too short */
+	CHECK(!zz_overlay_source_valid(4097, 240, 14)); /* too wide */
+	CHECK(!zz_overlay_source_valid(320, 4097, 14)); /* too tall */
+	CHECK(!zz_overlay_source_valid(320, 240, 9));   /* RGB source */
+	CHECK(!zz_overlay_source_valid(0, 0, 14));
+}
+
+static void test_apply_tags(void)
+{
+	struct ZZOverlayState st;
+	memset(&st, 0, sizeof(st));
+
+	/* geometry/key/active tags are "dirty" (firmware must see them) */
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_ACTIVE, 1) == 1);
+	CHECK(st.active == 1);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_LEFT, (uint32_t)-12) == 1);
+	CHECK(st.dst_x == -12);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_TOP, 34) == 1);
+	CHECK(st.dst_y == 34);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_WIDTH, 320) == 1);
+	CHECK(st.dst_w == 320);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_HEIGHT, 240) == 1);
+	CHECK(st.dst_h == 240);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_OCCLUSION, 5) == 1);
+	CHECK(st.occlusion == 1);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_COLOR, 0xF81F) == 1);
+	CHECK(st.color_key == 0xF81F);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_FORMAT, 14) == 1);
+	CHECK(st.rgbformat == 14);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_SOURCEWIDTH, 640) == 1);
+	CHECK(st.src_w == 640);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_SOURCEHEIGHT, 360) == 1);
+	CHECK(st.src_h == 360);
+
+	/* clip + brightness are stored but NOT dirty (WinUAE parity:
+	 * accepted and echoed, never applied) */
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_CLIPLEFT, 3) == 0);
+	CHECK(st.clip_l == 3);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_CLIPTOP, 4) == 0);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_CLIPWIDTH, 5) == 0);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_CLIPHEIGHT, 6) == 0);
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_BRIGHTNESS, 0x1234) == 0);
+	CHECK(st.brightness == 0x1234);
+
+	/* unknown tags: ignored, not dirty */
+	CHECK(zz_overlay_apply_tag(&st, 0x80000030u, 7) == 0);
+	CHECK(zz_overlay_apply_tag(&st, 0, 7) == 0);
+}
+
+static void test_query_tags(void)
+{
+	struct ZZOverlayState st;
+	uint32_t out = 0xDEADBEEF;
+	memset(&st, 0, sizeof(st));
+	st.active = 1;
+	st.dst_x = -5;
+	st.dst_y = 10;
+	st.dst_w = 300;
+	st.dst_h = 200;
+	st.src_w = 640;
+	st.src_h = 360;
+	st.rgbformat = 14;
+	st.color_key = 0xAA55AA55;
+	st.occlusion = 1;
+	st.brightness = 9;
+	st.clip_l = 1;
+
+	/* limits answered even without a live feature */
+	CHECK(zz_overlay_query_tag(&st, 0, 0, ZZ_FA_MINWIDTH, &out) && out == 16);
+	CHECK(zz_overlay_query_tag(&st, 0, 0, ZZ_FA_MAXHEIGHT, &out) && out == 4096);
+	/* state queries need a live feature */
+	CHECK(!zz_overlay_query_tag(&st, 0, 0, ZZ_FA_ACTIVE, &out));
+
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_ACTIVE, &out) && out == 1);
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_LEFT, &out) &&
+		(int32_t)out == -5);
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_WIDTH, &out) && out == 300);
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_SOURCEWIDTH, &out) && out == 640);
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_FORMAT, &out) && out == 14);
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_COLOR, &out) && out == 0xAA55AA55);
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_BITMAP, &out) && out == 0x40001234);
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_BRIGHTNESS, &out) && out == 9);
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_CLIPLEFT, &out) && out == 1);
+
+	/* unknown queries unanswered */
+	CHECK(!zz_overlay_query_tag(&st, 1, 0, 0x80000030u, &out));
+	CHECK(!zz_overlay_query_tag(&st, 1, 0, 0, &out));
+}
+
+int main(void)
+{
+	test_variant_map();
+	test_format_mask();
+	test_source_validation();
+	test_apply_tags();
+	test_query_tags();
+
+	if (failures) {
+		printf("%d of %d checks failed\n", failures, checks);
+		return 1;
+	}
+
+	printf("all %d overlay feature checks passed\n", checks);
+	return 0;
+}

--- a/rtg/tests/overlay_feature_test.c
+++ b/rtg/tests/overlay_feature_test.c
@@ -99,9 +99,27 @@ static void test_apply_tags(void)
 	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_BRIGHTNESS, 0x1234) == 0);
 	CHECK(st.brightness == 0x1234);
 
+	/* FA_Pen is a key alias (boardinfo.h: the RGB-mode key pen) */
+	CHECK(zz_overlay_apply_tag(&st, ZZ_FA_PEN, 0x00FF00FF) == 1);
+	CHECK(st.color_key == 0x00FF00FF);
+
 	/* unknown tags: ignored, not dirty */
 	CHECK(zz_overlay_apply_tag(&st, 0x80000030u, 7) == 0);
 	CHECK(zz_overlay_apply_tag(&st, 0, 7) == 0);
+}
+
+static void test_create_only_tags(void)
+{
+	/* source geometry/format cannot change under a live feature (the
+	 * backing bitmap was allocated at CreateFeature size) */
+	CHECK(zz_overlay_tag_create_only(ZZ_FA_FORMAT));
+	CHECK(zz_overlay_tag_create_only(ZZ_FA_SOURCEWIDTH));
+	CHECK(zz_overlay_tag_create_only(ZZ_FA_SOURCEHEIGHT));
+	CHECK(!zz_overlay_tag_create_only(ZZ_FA_ACTIVE));
+	CHECK(!zz_overlay_tag_create_only(ZZ_FA_LEFT));
+	CHECK(!zz_overlay_tag_create_only(ZZ_FA_WIDTH));
+	CHECK(!zz_overlay_tag_create_only(ZZ_FA_COLOR));
+	CHECK(!zz_overlay_tag_create_only(ZZ_FA_PEN));
 }
 
 static void test_query_tags(void)
@@ -135,6 +153,7 @@ static void test_query_tags(void)
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_SOURCEWIDTH, &out) && out == 640);
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_FORMAT, &out) && out == 14);
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_COLOR, &out) && out == 0xAA55AA55);
+	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_PEN, &out) && out == 0xAA55AA55);
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_BITMAP, &out) && out == 0x40001234);
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_BRIGHTNESS, &out) && out == 9);
 	CHECK(zz_overlay_query_tag(&st, 1, 0x40001234, ZZ_FA_CLIPLEFT, &out) && out == 1);
@@ -150,6 +169,7 @@ int main(void)
 	test_format_mask();
 	test_source_validation();
 	test_apply_tags();
+	test_create_only_tags();
 	test_query_tags();
 
 	if (failures) {

--- a/rtg/zz9000.h
+++ b/rtg/zz9000.h
@@ -273,6 +273,7 @@ enum zz9k_card_features {
   CARD_FEATURE_NONE,
   CARD_FEATURE_SECONDARY_PALETTE,
   CARD_FEATURE_NONSTANDARD_VSYNC,
+  CARD_FEATURE_VIDEO_OVERLAY,
   CARD_FEATURE_NUM,
 };
 
@@ -295,6 +296,8 @@ enum gfx_dma_op {
   OP_ETH_USB_OFFSETS,
   OP_SET_SPLIT_POS,
   OP_SET_PALETTE,
+  OP_WRITE_YUV,
+  OP_VIDEO_OVERLAY,
   OP_NUM,
 };
 
@@ -321,6 +324,24 @@ enum gfxdata_u8_types {
   GFXDATA_U8_DRAWMODE,
   GFXDATA_U8_LINE_PATTERN_OFFSET,
   GFXDATA_U8_LINE_PADDING,
+  GFXDATA_U8_YUV_VARIANT,
+  GFXDATA_U8_OVERLAY_SUBCMD,
+};
+
+enum overlay_subcmd {
+  OVERLAY_SUBCMD_SET,
+  OVERLAY_SUBCMD_OFF,
+};
+
+/* Packed 4:2:2 macropixel byte orders (mirror firmware gfx.h; the old
+ * Picasso96.h comments have U and V interchanged, fixed in P96 3.6.3). */
+enum yuv422_variant {
+  YUV422_VARIANT_CGX,   /* RGBFB_YUV422CGX: Y0 U Y1 V (YUY2) */
+  YUV422_VARIANT_STD,   /* RGBFB_YUV422:    Y1 V Y0 U */
+  YUV422_VARIANT_PC,    /* RGBFB_YUV422PC:  U Y0 V Y1 (UYVY) */
+  YUV422_VARIANT_PA,    /* RGBFB_YUV422PA:  Y0 Y1 U V */
+  YUV422_VARIANT_PAPC,  /* RGBFB_YUV422PAPC: V U Y1 Y0 */
+  YUV422_VARIANT_NUM,
 };
 
 #pragma pack(4)


### PR DESCRIPTION
## What

The driver side of P96 picture-in-picture. The WriteYUVRect probe (#40) proved P96 never reaches any PIP render hook unless the board advertises the capability — `BIF_VIDEOWINDOW` plus the Features API. This implements it, modeled on WinUAE's uaegfx overlay (the only public reference for the contract):

- **`ZZ_CreateFeature`** (`SFT_MEMORYWINDOW`, one overlay at a time): parses `FA_SourceWidth/Height/Format`, validates 16–4096 and the accepted packed 4:2:2 formats (CGX/422/PC = the YUY2/UYVY family), allocates the YUV source bitmap **through our own AllocBitMap** with the PicassoIV/WinUAE tag set (Clear+Displayable+Visible), enables the firmware `CARD_FEATURE_VIDEO_OVERLAY` gate and pushes state via `OP_VIDEO_OVERLAY`. A non-zero firmware status (e.g. shadow-buffer allocation failure) fails the PIP open cleanly.
- **`ZZ_SetFeatureAttrs`** re-sends full state on geometry/key/active changes; clip + brightness are stored-and-echoed but not applied (WinUAE parity). **`ZZ_GetFeatureAttrs`** answers Min 16 / Max 4096, geometry echoes and `FA_BitMap` (writing through `ti_Data` pointers). **`ZZ_DeleteFeature`** pushes OFF and frees the source bitmap.
- **AllocBitMap accepts the packed 4:2:2 formats** (2 bytes/pixel, depth 16) via a local pitch helper — the P96-facing `CalculateBytesPerRow` and `b->RGBFormats` stay YUV-blind. `GetCompatibleFormats` ORs the overlay source formats in only while the hooks are installed.
- **Gating** like the other features: Z3 + firmware ≥ 2.6 + off-screen bitmap hooks present; kill switches `ENV:ZZ9000-NO-PIP`, ZZ9000.CFG `video_overlay`, `VIDEOPIP` tooltype (wins). The color key travels via the pen convention (raw 68k ULONG, firmware reads it unswapped).

Pure logic (tag apply/query, validation, variant map) lives in `rtg/overlay_feature.h` with a host suite; the off-screen bitmap tests cover the new YUV helpers. DEBUG builds log all Feature tag traffic — that's how the two remaining contract unknowns (ti_Data store-pointer semantics, cookie shape) get pinned on real P96 during the bench.

## Relationship to #40

This branch **contains** #40's commits (the WriteYUVRect probe + the `ZZ9000-debug.card` CI artifact), so merging this PR delivers those too — #40 can then be closed as superseded. The WriteYUVRect hook itself stays as a logging probe: with PIP capability now advertised, P96 may actually start calling it, and the captured log decides whether a Stage-B accelerated WriteYUVRect is still worth building.

## Bench

Companion firmware PR: BlitterStudio/zz9000-firmware#54 (rev 2.6 BOOT.bin). Use the `ZZ9000-debug.card` CI artifact with Sashimi for the first session — the Feature tag logs validate the contract details. Checklist highlights: PIP open/colors vs a reference (WinUAE side-by-side), drag-resize (tear check), key/occlusion on 16- and 32-bit screens, mode-switch + 8-bit hide, MP3-via-MHI during PIP (core-1 interleaving), kill switches, 30-min soak.