### PR TITLE
Keep card feature selectors out of blitter cache

### DIFF
--- a/rtg/blitter_cache.h
+++ b/rtg/blitter_cache.h
@@ -45,6 +45,13 @@ static inline void blitter_cache_select(struct BlitterRegisterCache *cache,
 	}
 }
 
+static inline void blitter_cache_invalidate(struct BlitterRegisterCache *cache,
+	const volatile void *registers, uint32_t bits)
+{
+	blitter_cache_select(cache, registers);
+	cache->valid &= ~bits;
+}
+
 static inline int blitter_cache_write16_needed(struct BlitterRegisterCache *cache,
 	const volatile void *registers, uint32_t bit, uint16_t *slot, uint16_t value)
 {

--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -352,6 +352,7 @@ static LONG tooltype_nonstandard_vsync(char **tool_types, LONG current) {
 }
 
 static inline void zzwrite16(volatile uint16_t* reg, uint16_t value);
+static inline void selectCardFeature(MNTZZ9KRegs* registers, UWORD feature);
 
 static struct ConfigDev *find_unconfigured_configdev(struct ExpansionBase *ExpansionBase, UWORD manufacturer, UBYTE product) {
 	struct ConfigDev *cd = NULL;
@@ -375,7 +376,7 @@ static void apply_vcap_settings(MNTZZ9KRegs *regs, LONG scandoubler_800x600) {
 }
 
 static void apply_nonstandard_vsync_settings(MNTZZ9KRegs *regs, LONG nonstandard_vsync_mode) {
-	zzwrite16(&regs->blitter_user1, CARD_FEATURE_NONSTANDARD_VSYNC);
+	selectCardFeature(regs, CARD_FEATURE_NONSTANDARD_VSYNC);
 	zzwrite16(&regs->set_feature_status, (UWORD)nonstandard_vsync_mode);
 }
 
@@ -472,6 +473,15 @@ static inline void writeBlitterUser1(MNTZZ9KRegs* registers, UWORD value) {
 			BLITTER_CACHE_USER1, &blitter_register_cache.user1, value)) {
 		zzwrite16(&registers->blitter_user1, value);
 	}
+}
+
+/* USER1 doubles as the selector for set_feature_status. Feature commands must
+ * always reach the card, then leave USER1 invalid in the blitter cache because
+ * the selector is not a reusable blitter operand. */
+static inline void selectCardFeature(MNTZZ9KRegs* registers, UWORD feature) {
+	zzwrite16(&registers->blitter_user1, feature);
+	blitter_cache_invalidate(&blitter_register_cache, registers,
+		BLITTER_CACHE_USER1);
 }
 
 static inline void writeBlitterUser2(MNTZZ9KRegs* registers, UWORD value) {
@@ -1130,7 +1140,7 @@ void SetColorArray(__REGA0(struct BoardInfo *b), __REGD0(UWORD start), __REGD1(U
 
 	if (start >= 256) {
 		if (!b->CardData[ZZ_CARD_DATA_SECONDARY_PALETTE]) {
-			writeBlitterUser1(registers, CARD_FEATURE_SECONDARY_PALETTE);
+			selectCardFeature(registers, CARD_FEATURE_SECONDARY_PALETTE);
 			zzwrite16(&registers->set_feature_status, 1);
 			b->CardData[ZZ_CARD_DATA_SECONDARY_PALETTE] = 1;
 		}
@@ -1243,7 +1253,7 @@ void SetDPMSLevel(__REGA0(struct BoardInfo *b), __REGD0(ULONG level)) {
 		return;
 
 	MNTZZ9KRegs *registers = (MNTZZ9KRegs *)b->RegisterBase;
-	writeBlitterUser1(registers, CARD_FEATURE_DPMS);
+	selectCardFeature(registers, CARD_FEATURE_DPMS);
 	zzwrite16(&registers->set_feature_status, (UWORD)level);
 }
 
@@ -2321,7 +2331,7 @@ APTR ZZ_CreateFeature(__REGA0(struct BoardInfo *b), __REGD0(ULONG type), __REGA1
 	/* enable the firmware master gate (the vblank ISR checks it) */
 	{
 		MNTZZ9KRegs* registers = (MNTZZ9KRegs*)b->RegisterBase;
-		zzwrite16(&registers->blitter_user1, CARD_FEATURE_VIDEO_OVERLAY);
+		selectCardFeature(registers, CARD_FEATURE_VIDEO_OVERLAY);
 		zzwrite16(&registers->set_feature_status, 1);
 	}
 

--- a/rtg/tests/register_cache_test.c
+++ b/rtg/tests/register_cache_test.c
@@ -57,6 +57,14 @@ int main(void)
 		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_USER2,
 			&user2, 0x5a), 0);
 
+	blitter_cache_invalidate(&cache, &regs_a, BLITTER_CACHE_USER1);
+	expect_write("invalidated user1 writes",
+		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_USER1,
+			&user1, 12), 1);
+	expect_write("user2 survives user1 invalidate",
+		blitter_cache_write16_needed(&cache, &regs_a, BLITTER_CACHE_USER2,
+			&user2, 0x5a), 0);
+
 	expect_write("first rgb2 writes",
 		blitter_cache_write32_needed(&cache, &regs_a, BLITTER_CACHE_RGB2,
 			&rgb2, 0x11223344), 1);


### PR DESCRIPTION
## Summary
- keep `set_feature_status` selectors out of the reusable blitter USER1 cache
- invalidate only USER1 after every feature-selector write
- cover targeted cache invalidation with a regression test

Follow-up to the delayed review finding on #42.

## Validation
- all four RTG host tests pass from fresh binaries
- production `ZZ9000.card` builds with `sacredbanana/amiga-compiler:m68k-amigaos`
- `git diff --check`