### PR TITLE
fix(rtg): preserve complement line joins

### DIFF
--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -1757,6 +1757,16 @@ void DrawLine(__REGA0(struct BoardInfo *b), __REGA1(struct RenderInfo *r), __REG
 	if (!b || !l || !r)
 		return;
 
+	/* Line does not expose the RastPort's FRST_DOT state, so an accelerated
+	 * COMPLEMENT line cannot tell a fresh Draw from a connected Draw. Processing
+	 * a shared vertex twice is observable with XOR. Keep every other mode on the
+	 * fast path and let Picasso96 preserve exact join ownership for COMPLEMENT. */
+	if (l->DrawMode & COMPLEMENT) {
+		if (b->DrawLineDefault)
+			b->DrawLineDefault(b, r, l, mask, format);
+		return;
+	}
+
 	uint16_t colormode = mnt_colormode(format);
 	if (colormode == MNTVA_COLOR_NO_USE) {
 		if (b->DrawLineDefault)


### PR DESCRIPTION
## Summary

- keep ZZ9000 acceleration for JAM1, JAM2, patterned, and inverse-video lines
- route only COMPLEMENT/XOR lines through Picasso96 DrawLineDefault
- preserve the established inclusive Line.Length behavior for accelerated modes

## Root cause

The Picasso96 Line callback does not expose the RastPort FRST_DOT state. It therefore cannot tell a fresh Draw from a connected Draw whose shared start pixel must be skipped. That distinction is unobservable for idempotent drawing modes but essential for COMPLEMENT, where processing a shared vertex twice cancels the XOR.

The p96cts comparison runs confirmed that Line.pad does not carry this state: treating its low bit as FRST_DOT made the first pattern/JAM2 pixel disappear and still left the complement closing vertex wrong.

A stateful endpoint heuristic would be faster in a microbenchmark but would fail for independent lines sharing coordinates, clipped segments, interleaved surfaces, or tasks. Falling back only for COMPLEMENT is the optimized robust solution.

## Testing

- p96cts 0.2 in Amiberry at 1280x1024x8: solid, pattern, JAM2, INVERSVID, and COMPLEMENT all pass with zero differing pixels
- make rtg-tests
- make rtg
- python3 -m unittest tools/tests/test_repo_tooling.py
- make quality
- tools/check-release.sh --quick
- rebuilt stock Amiberry after removing the experimental protocol change

## Companion PR

- BlitterStudio/zz9000-firmware#58 hardens the firmware solid-line dispatcher for non-JAM1 modes

No firmware update is required for the complement join fix itself.

Closes #51