### PR TITLE
rtg: upload the template when BytesPerRow is zero

### DIFF
--- a/rtg/mntgfx-gcc.c
+++ b/rtg/mntgfx-gcc.c
@@ -1642,7 +1642,15 @@ void BlitTemplate(__REGA0(struct BoardInfo *b), __REGA1(struct RenderInfo *r), _
 		zz_template_addr = b->MemorySize;
 	}
 
-	memcpy((uint8_t*)(((uint32_t)b->MemoryBase)+zz_template_addr), t->Memory, t->BytesPerRow * h);
+	/* BytesPerRow is the offset from one template line to the next, not a
+	 * size, and P96 does pass 0: the template is then a single line that
+	 * repeats down the whole rectangle. BytesPerRow * h is 0 bytes for that,
+	 * leaving the board to blit whatever the previous op left in the template
+	 * buffer. Copy the one line the blit actually reads instead. */
+	uint32_t row_bytes = ((uint32_t)t->XOffset + (uint32_t)w + 7) / 8;
+	uint32_t template_bytes =
+		t->BytesPerRow ? (uint32_t)t->BytesPerRow * (uint32_t)h : row_bytes;
+	memcpy((uint8_t*)(((uint32_t)b->MemoryBase)+zz_template_addr), t->Memory, template_bytes);
 
 	if (b->CardFlags & CARDFLAG_ZORRO_3) {
 		dmy_cache


### PR DESCRIPTION
`Template->BytesPerRow` is defined by the [P96 driver docs](https://wiki.icomp.de/wiki/P96_Driver_Development#BlitTemplate) as "the byte offset from one line of the template to another" over data that is "logically one long strip" -- an offset, not a size. P96 does pass 0, meaning the single line repeats down the whole rectangle.

`BlitTemplate` sizes its upload as `t->BytesPerRow * h`, which is **0 bytes** in that case:

```c
memcpy((uint8_t*)(((uint32_t)b->MemoryBase)+zz_template_addr), t->Memory, t->BytesPerRow * h);
```

The template data never reaches the board, so the blit renders whatever the previous op left in the template buffer at `zz_template_addr`.

## How it shows up

`p96cts BltPattern-drawmodes` fails on the two `JAM2 | COMPLEMENT` columns. P96 renders those by converting the pattern into a one-line repeating template and calling `BlitTemplate` with `DrawMode = COMPLEMENT` and `BytesPerRow = 0`. The preceding op is a `RECT_PATTERN` writing to the same template address, so the board complements through the stale pattern data instead of the intended row.

## The fix

Copy the one line the blit actually reads when the stride is zero. Non-zero strides are unaffected, so this is a strict superset of the previous behaviour.

## Testing

Verified under Amiberry with `p96cts ZZ9000 1280x1024x8`: `BltPattern-drawmodes` goes from FAIL to PASS, and the full suite is 23/23 with no other scene changing.

This needs BlitterStudio/amiberry#2236 as well -- Amiberry's `zz_template_rect()` rejects a zero source pitch outright, so it would discard the blit even once the data arrives. Fixed in a companion PR.

The same bug is present verbatim in the Z3660 driver, which forked this code; fixing it there makes `BltPattern-drawmodes` pass on Z3660 under Copperline. with no emulator change, since Copperline already handles a zero stride correctly.

Refs BlitterStudio/amiberry#2236

🤖 Generated with [Claude Code](https://claude.com/claude-code)